### PR TITLE
Fix #38 & #40: Change CRT linkage mode for GTest on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 2.8.7)
+
+# Allow use of project folders for IDEs like Visual Studio, so we
+# could organize projects into relevant folders: "cpr", "tests" & "external (libraries)".
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")
+
 project(cpr)
 
 if(NOT ${CMAKE_VERSION} LESS 3.2)

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -4,6 +4,8 @@ include_directories(
     ${CURL_INCLUDE_DIRS})
 
 add_library(${CPR_LIBRARIES}
+
+    # Source files
     auth.cpp
     cookies.cpp
     cprtypes.cpp
@@ -13,7 +15,24 @@ add_library(${CPR_LIBRARIES}
     payload.cpp
     proxies.cpp
     session.cpp
-    util.cpp)
+    util.cpp 
+
+    # Header files (useful in IDEs)
+    "${CPR_INCLUDE_DIRS}/api.h"
+    "${CPR_INCLUDE_DIRS}/auth.h"
+    "${CPR_INCLUDE_DIRS}/cookies.h"
+    "${CPR_INCLUDE_DIRS}/cpr.h"
+    "${CPR_INCLUDE_DIRS}/cprtypes.h"
+    "${CPR_INCLUDE_DIRS}/curlholder.h"
+    "${CPR_INCLUDE_DIRS}/digest.h"
+    "${CPR_INCLUDE_DIRS}/multipart.h"
+    "${CPR_INCLUDE_DIRS}/parameters.h"
+    "${CPR_INCLUDE_DIRS}/payload.h"
+    "${CPR_INCLUDE_DIRS}/proxies.h"
+    "${CPR_INCLUDE_DIRS}/response.h"
+    "${CPR_INCLUDE_DIRS}/session.h"
+    "${CPR_INCLUDE_DIRS}/timeout.h"
+    "${CPR_INCLUDE_DIRS}/util.h")
 
 message(STATUS "Using CURL_LIBRARIES: ${CURL_LIBRARIES}.")
 target_link_libraries(${CPR_LIBRARIES}

--- a/include/response.h
+++ b/include/response.h
@@ -16,6 +16,7 @@ class Response {
              const double& elapsed, const Cookies& cookies)
         : status_code{status_code}, text{text}, header{header}, url{url}, elapsed{elapsed},
           cookies{cookies} {};
+    Response() = default;
 
     long status_code;
     std::string text;

--- a/opt/CMakeLists.txt
+++ b/opt/CMakeLists.txt
@@ -66,6 +66,12 @@ if(BUILD_CPR_TESTS)
     if(NOT USE_SYSTEM_GTEST OR NOT GTEST_FOUND)
         message(STATUS "Not using system gtest, using built-in googletest project instead.")
         add_subdirectory(googletest)
+        if(MSVC)
+            # By default, GTest compiles on Windows in CRT static linkage mode. We use this
+            # variable to force it into using the CRT in dynamic linkage (DLL), just as CPR
+            # does.
+            set(gtest_force_shared_crt ON)
+        endif()
         set(GTEST_FOUND TRUE)
         set(GTEST_LIBRARIES gtest)
         set(GTEST_MAIN_LIBRARIES gtest_main)

--- a/opt/CMakeLists.txt
+++ b/opt/CMakeLists.txt
@@ -56,6 +56,10 @@ set_cache_variable(CURL_FOUND "Set if libcurl is found or built")
 set_cache_variable(CURL_LIBRARIES "Location of libcurl")
 set_cache_variable(CURL_INCLUDE_DIRS "Location of curl include files")
 
+# Group under the "external" project folder in IDEs such as Visual Studio.
+set_property(TARGET curl PROPERTY FOLDER "external")
+set_property(TARGET libcurl PROPERTY FOLDER "external")
+
 
 # GTest configuration
 
@@ -86,6 +90,10 @@ if(BUILD_CPR_TESTS)
     set_cache_variable(GTEST_INCLUDE_DIRS "Location of gtest include files")
 endif()
 
+# Group under the "tests/gtest" project folder in IDEs such as Visual Studio.
+set_property(TARGET gtest PROPERTY FOLDER "tests/gtest")
+set_property(TARGET gtest_main PROPERTY FOLDER "tests/gtest")
+
 
 # Mongoose configuration
 
@@ -100,3 +108,6 @@ if(BUILD_CPR_TESTS)
     set_cache_variable(MONGOOSE_LIBRARIES "Location of libmongoose")
     set_cache_variable(MONGOOSE_INCLUDE_DIRS "Location of mongoose include files")
 endif()
+
+# Group under the "external" project folder in IDEs such as Visual Studio.
+set_property(TARGET mongoose PROPERTY FOLDER "external")

--- a/opt/CMakeLists.txt
+++ b/opt/CMakeLists.txt
@@ -50,15 +50,15 @@ if(NOT USE_SYSTEM_CURL OR NOT CURL_FOUND)
     set(CURL_INCLUDE_DIRS
         ${CURL_SOURCE_DIR}/include
         ${CURL_BINARY_DIR}/include/curl)
+        
+    # Group under the "external" project folder in IDEs such as Visual Studio.
+    set_property(TARGET curl PROPERTY FOLDER "external")
+    set_property(TARGET libcurl PROPERTY FOLDER "external")
 endif()
 
 set_cache_variable(CURL_FOUND "Set if libcurl is found or built")
 set_cache_variable(CURL_LIBRARIES "Location of libcurl")
 set_cache_variable(CURL_INCLUDE_DIRS "Location of curl include files")
-
-# Group under the "external" project folder in IDEs such as Visual Studio.
-set_property(TARGET curl PROPERTY FOLDER "external")
-set_property(TARGET libcurl PROPERTY FOLDER "external")
 
 
 # GTest configuration
@@ -81,6 +81,10 @@ if(BUILD_CPR_TESTS)
         set(GTEST_MAIN_LIBRARIES gtest_main)
         set(GTEST_BOTH_LIBRARIES gtest gtest_main)
         set(GTEST_INCLUDE_DIRS ${gtest_SOURCE_DIR}/include)
+        
+        # Group under the "tests/gtest" project folder in IDEs such as Visual Studio.
+    set_property(TARGET gtest PROPERTY FOLDER "tests/gtest")
+    set_property(TARGET gtest_main PROPERTY FOLDER "tests/gtest")
     endif()
 
     set_cache_variable(GTEST_FOUND "Set if libgtest was found or built")
@@ -89,10 +93,6 @@ if(BUILD_CPR_TESTS)
     set_cache_variable(GTEST_BOTH_LIBRARIES "Location of both gtest libraries")
     set_cache_variable(GTEST_INCLUDE_DIRS "Location of gtest include files")
 endif()
-
-# Group under the "tests/gtest" project folder in IDEs such as Visual Studio.
-set_property(TARGET gtest PROPERTY FOLDER "tests/gtest")
-set_property(TARGET gtest_main PROPERTY FOLDER "tests/gtest")
 
 
 # Mongoose configuration
@@ -107,7 +107,7 @@ if(BUILD_CPR_TESTS)
     set_cache_variable(MONGOOSE_FOUND "Set if libmongoose was found or built")
     set_cache_variable(MONGOOSE_LIBRARIES "Location of libmongoose")
     set_cache_variable(MONGOOSE_INCLUDE_DIRS "Location of mongoose include files")
+    
+    # Group under the "external" project folder in IDEs such as Visual Studio.
+    set_property(TARGET mongoose PROPERTY FOLDER "external")
 endif()
-
-# Group under the "external" project folder in IDEs such as Visual Studio.
-set_property(TARGET mongoose PROPERTY FOLDER "external")

--- a/opt/CMakeLists.txt
+++ b/opt/CMakeLists.txt
@@ -65,13 +65,13 @@ if(BUILD_CPR_TESTS)
     endif()
     if(NOT USE_SYSTEM_GTEST OR NOT GTEST_FOUND)
         message(STATUS "Not using system gtest, using built-in googletest project instead.")
-        add_subdirectory(googletest)
         if(MSVC)
             # By default, GTest compiles on Windows in CRT static linkage mode. We use this
             # variable to force it into using the CRT in dynamic linkage (DLL), just as CPR
             # does.
             set(gtest_force_shared_crt ON)
         endif()
+        add_subdirectory(googletest)
         set(GTEST_FOUND TRUE)
         set(GTEST_LIBRARIES gtest)
         set(GTEST_MAIN_LIBRARIES gtest_main)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,16 @@
 macro(add_cpr_test _TEST_NAME)
     add_executable(${_TEST_NAME}_tests
-        ${_TEST_NAME}_tests.cpp server.cpp)
+        ${_TEST_NAME}_tests.cpp server.cpp server.h)
     target_link_libraries(${_TEST_NAME}_tests
         ${GTEST_LIBRARIES}
         ${CPR_LIBRARIES}
         ${MONGOOSE_LIBRARIES})
     add_test(NAME cpr_${_TEST_NAME}_tests COMMAND ${_TEST_NAME}_tests)
+    if(WIN32)
+        add_custom_command(TARGET ${_TEST_NAME}_tests POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy
+                                $<TARGET_FILE_DIR:libcurl>/libcurl.dll $<TARGET_FILE_DIR:${_TEST_NAME}_tests>)
+    endif()
 endmacro()
 
 include_directories(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,8 @@ macro(add_cpr_test _TEST_NAME)
         ${CPR_LIBRARIES}
         ${MONGOOSE_LIBRARIES})
     add_test(NAME cpr_${_TEST_NAME}_tests COMMAND ${_TEST_NAME}_tests)
+    # Group under the "tests" project folder in IDEs such as Visual Studio.
+    set_property(TARGET ${_TEST_NAME}_tests PROPERTY FOLDER "tests")
     if(WIN32)
         add_custom_command(TARGET ${_TEST_NAME}_tests POST_BUILD
                            COMMAND ${CMAKE_COMMAND} -E copy


### PR DESCRIPTION
GTest, by default, links statically while `CPR` links dynamically. Fortunately, GTest has a CMake variable in place to fix this.