### PR TITLE
Modernize code (more idiomatic C++11 and faster container initialization)

### DIFF
--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -4,11 +4,8 @@
 
 namespace cpr {
 
-    Cookies::Cookies(const std::initializer_list<std::pair<std::string, std::string>>& pairs) {
-        for (auto& pair : pairs) {
-            map_[pair.first] = pair.second;
-        }
-    }
+    Cookies::Cookies(const std::initializer_list<std::pair<const std::string, std::string>>& pairs) 
+        : map_{pairs} { }
 
     std::string Cookies::GetEncoded() const {
         std::stringstream stream;

--- a/cpr/cprtypes.cpp
+++ b/cpr/cprtypes.cpp
@@ -9,8 +9,9 @@ namespace cpr {
     }
 
     void CaseInsenstiveCompare::char_to_lower(char& c) {
-        if (c >= 'A' && c <= 'Z')
-        c += ('a' - 'A');
+        if (c >= 'A' && c <= 'Z') {
+            c += ('a' - 'A');
+        }
     }
 
     std::string CaseInsenstiveCompare::to_lower(const std::string& a) {

--- a/cpr/multipart.cpp
+++ b/cpr/multipart.cpp
@@ -2,10 +2,6 @@
 
 namespace cpr {
 
-    Multipart::Multipart(const std::initializer_list<Part>& parts) {
-        for (auto part = parts.begin(); part != parts.end(); ++part) {
-            this->parts.push_back(*part);
-        }
-    }
-
+    Multipart::Multipart(const std::initializer_list<Part>& parts)
+        : parts{parts} { }
 }

--- a/cpr/parameters.cpp
+++ b/cpr/parameters.cpp
@@ -8,12 +8,12 @@
 namespace cpr {
 
     Parameters::Parameters(const std::initializer_list<Parameter>& parameters) {
-        for (auto parameter = parameters.begin(); parameter != parameters.end(); ++parameter) {
+        for (const auto& parameter : parameters) {
             if (!content.empty()) {
                 content += "&";
             }
-            auto escaped = cpr::util::urlEncode(parameter->value);
-            content += parameter->key + "=" + escaped;
+            auto escaped = cpr::util::urlEncode(parameter.value);
+            content += parameter.key + "=" + escaped;
         }
     }
 

--- a/cpr/payload.cpp
+++ b/cpr/payload.cpp
@@ -8,12 +8,12 @@
 namespace cpr {
 
     Payload::Payload(const std::initializer_list<Pair>& pairs) {
-        for (auto pair = pairs.begin(); pair != pairs.end(); ++pair) {
+        for (const auto& pair : pairs) {
             if (!content.empty()) {
                 content += "&";
             }
-            auto escaped = cpr::util::urlEncode(pair->value);
-            content += pair->key + "=" + escaped;
+            auto escaped = cpr::util::urlEncode(pair.value);
+            content += pair.key + "=" + escaped;
         }
     }
 

--- a/cpr/proxies.cpp
+++ b/cpr/proxies.cpp
@@ -7,11 +7,8 @@
 
 namespace cpr {
 
-    Proxies::Proxies(const std::initializer_list<std::pair<std::string, std::string>>& hosts) {
-        for (auto& host : hosts) {
-            hosts_[host.first] = host.second;
-        }
-    }
+    Proxies::Proxies(const std::initializer_list<std::pair<const std::string, std::string>>& hosts) 
+        : hosts_{hosts} { }
 
     bool Proxies::has(const std::string& protocol) {
         return hosts_.count(protocol) > 0;

--- a/include/cookies.h
+++ b/include/cookies.h
@@ -11,7 +11,7 @@ namespace cpr {
     class Cookies {
       public:
         Cookies() {}
-        Cookies(const std::initializer_list<std::pair<std::string, std::string>>& pairs);
+        Cookies(const std::initializer_list<std::pair<const std::string, std::string>>& pairs);
         Cookies(const std::map<std::string, std::string>& map) : map_{map} {}
 
         std::string& operator[](const std::string& key);

--- a/include/proxies.h
+++ b/include/proxies.h
@@ -11,7 +11,7 @@ namespace cpr {
     class Proxies {
       public:
         Proxies() {}
-        Proxies(const std::initializer_list<std::pair<std::string, std::string>>& hosts);
+        Proxies(const std::initializer_list<std::pair<const std::string, std::string>>& hosts);
 
         bool has(const std::string& protocol);
         const std::string& operator[](const std::string& protocol);


### PR DESCRIPTION
Great talk and great library. 
Here's a small and simple pull request to modernize some code.

* Most containers can be constructed using `std::initializer_list`. 

* When dealing with initializer lists of key-value pairs, the key should be `const`. 

* Use for-each loops instead of iterators-based loops.