### PR TITLE
Special case v1 cookies in GetEncoded()

### DIFF
--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -10,14 +10,15 @@ Cookies::Cookies(const std::initializer_list<std::pair<const std::string, std::s
 std::string Cookies::GetEncoded() const {
     std::stringstream stream;
     for (const auto& item : map_) {
+        stream << cpr::util::urlEncode(item.first) << "=";
         // special case version 1 cookies, which can be distinguished by
         // beginning and trailing quotes
         if (!item.second.empty() && item.second.front() == '"' && item.second.back() == '"') {
-            stream << cpr::util::urlEncode(item.first) << "=" << item.second << "; ";
+            stream << item.second;
         } else {
-            stream << cpr::util::urlEncode(item.first) << "=" << cpr::util::urlEncode(item.second)
-                   << "; ";
+            stream << cpr::util::urlEncode(item.second);
         }
+        stream << "; ";
     }
     return stream.str();
 }

--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -10,8 +10,14 @@ Cookies::Cookies(const std::initializer_list<std::pair<const std::string, std::s
 std::string Cookies::GetEncoded() const {
     std::stringstream stream;
     for (const auto& item : map_) {
-        stream << cpr::util::urlEncode(item.first) << "=" << cpr::util::urlEncode(item.second)
-               << "; ";
+        // special case version 1 cookies, which can be distinguished by
+        // beginning and trailing quotes
+        if (!item.second.empty() && item.second.front() == '"' && item.second.back() == '"') {
+            stream << cpr::util::urlEncode(item.first) << "=" << item.second << "; ";
+        } else {
+            stream << cpr::util::urlEncode(item.first) << "=" << cpr::util::urlEncode(item.second)
+                   << "; ";
+        }
     }
     return stream.str();
 }

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -79,6 +79,42 @@ TEST(CookiesTests, SingleCookieTest) {
     EXPECT_EQ(cookies["expires"], response.cookies["expires"]);
 }
 
+TEST(CookiesTests, CheckBasicCookieTest) {
+    // server validates whether the cookies are indeed present
+    auto url = Url{base + "/check_cookies.html"};
+    auto cookies = Cookies{{"cookie", "chocolate"}, {"icecream", "vanilla"}};
+    auto response = cpr::Get(url, cookies);
+    auto expected_text = std::string{"Hello world!"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+}
+
+TEST(CookiesTests, V1CookieTest) {
+    auto url = Url{base + "/v1_cookies.html"};
+    auto response = cpr::Get(url);
+    auto expected_text = std::string{"Hello world!"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+    auto cookies = response.cookies;
+    EXPECT_EQ("\"value with spaces (v1 cookie)\"", cookies["cookie"]);
+}
+
+TEST(CookiesTests, CheckV1CookieTest) {
+    // server validates whether the cookie is indeed present
+    auto url = Url{base + "/check_v1_cookies.html"};
+    auto cookies = Cookies{{"cookie", "\"value with spaces (v1 cookie)\""}};
+    auto response = cpr::Get(url, cookies);
+    auto expected_text = std::string{"Hello world!"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+}
+
 TEST(ParameterTests, SingleParameterTest) {
     auto url = Url{base + "/hello.html"};
     auto parameters = Parameters{{"key", "value"}};


### PR DESCRIPTION
Some application servers will put cookies in quotes if they contain certain characters. This happens with e.g. the base64 encoded session cookies for some webapps. In this case, url encoding the cookie actually breaks things on the recipient side of the request because the leading and trailing quotation marks were gobbled into %22s.

My fix was to simply special-case the scenario where we have a cookie value that begins and ends with a quotation mark, and to bypass the `urlEncode()` step for those. Maybe there's a better way of doing this, but this was the most obvious and fixed things for me.