### PR TITLE
allow construction of cpr::Payload objects with std::vector

### DIFF
--- a/cpr/payload.cpp
+++ b/cpr/payload.cpp
@@ -7,14 +7,14 @@
 
 namespace cpr {
 
-Payload::Payload(const std::initializer_list<Pair>& pairs) {
-    for (const auto& pair : pairs) {
-        if (!content.empty()) {
-            content += "&";
-        }
-        auto escaped = cpr::util::urlEncode(pair.value);
-        content += pair.key + "=" + escaped;
+Payload::Payload(const std::initializer_list<Pair>& pairs) : Payload(begin(pairs), end(pairs)) {}
+
+void Payload::AddPair(const Pair& pair) {
+    if (!content.empty()) {
+        content += "&";
     }
+    auto escaped = cpr::util::urlEncode(pair.value);
+    content += pair.key + "=" + escaped;
 }
 
 } // namespace cpr

--- a/include/payload.h
+++ b/include/payload.h
@@ -4,8 +4,10 @@
 #include <memory>
 #include <string>
 #include <initializer_list>
+#include <vector>
 
 #include "defines.h"
+#include "util.h"
 
 namespace cpr {
 
@@ -24,7 +26,15 @@ struct Pair {
 
 class Payload {
   public:
+    template <class It>
+    Payload(const It begin, const It end) {
+        for (It pair = begin; pair != end; ++pair) {
+            AddPair(*pair);
+        }
+    }
     Payload(const std::initializer_list<Pair>& pairs);
+
+    void AddPair(const Pair& pair);
 
     std::string content;
 };

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -27,6 +27,39 @@ TEST(UrlEncodedPostTests, UrlPostSingleTest) {
     EXPECT_EQ(201, response.status_code);
 }
 
+TEST(UrlEncodedPostTests, UrlPostAddPayloadPair) {
+    auto url = Url{base + "/url_post.html"};
+    auto payload = Payload{{"x", "1"}};
+    payload.AddPair({"y", "2"});
+    auto response = cpr::Post(url, Payload(payload));
+    auto expected_text = std::string{"{\n"
+                                             "  \"x\": 1,\n"
+                                             "  \"y\": 2,\n"
+                                             "  \"sum\": 3\n"
+                                             "}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+}
+
+TEST(UrlEncodedPostTests, UrlPostPayloadIteratorTest) {
+    auto url = Url{base + "/url_post.html"};
+    std::vector<Pair> payloadData;
+    payloadData.push_back({"x", "1"});
+    payloadData.push_back({"y", "2"});
+    auto response = cpr::Post(url, Payload(payloadData.begin(), payloadData.end()));
+    auto expected_text = std::string{"{\n"
+                                             "  \"x\": 1,\n"
+                                             "  \"y\": 2,\n"
+                                             "  \"sum\": 3\n"
+                                             "}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+}
+
 TEST(UrlEncodedPostTests, UrlPostEncodeTest) {
     auto url = Url{base + "/url_post.html"};
     auto response = cpr::Post(url, Payload{{"x", "hello world!!~"}});


### PR DESCRIPTION
if there is a better way to share the same code for these two constructors, please tell me and I'll update this pull request :)