### PR TITLE
"Parameters" class lacks a method to add a parameter

### DIFF
--- a/cpr/parameters.cpp
+++ b/cpr/parameters.cpp
@@ -9,12 +9,16 @@ namespace cpr {
 
 Parameters::Parameters(const std::initializer_list<Parameter>& parameters) {
     for (const auto& parameter : parameters) {
-        if (!content.empty()) {
-            content += "&";
-        }
-        auto escaped = cpr::util::urlEncode(parameter.value);
-        content += parameter.key + "=" + escaped;
+        AddParameter(parameter);
     }
+}
+
+void Parameters::AddParameter(const Parameter& parameter) {
+    if (!content.empty()) {
+        content += "&";
+    }
+    auto escaped = cpr::util::urlEncode(parameter.value);
+    content += parameter.key + "=" + escaped;
 }
 
 } // namespace cpr

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -23,6 +23,8 @@ class Parameters {
     Parameters() = default;
     Parameters(const std::initializer_list<Parameter>& parameters);
 
+    void AddParameter(const Parameter& parameter);
+
     std::string content;
 };
 

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -138,6 +138,19 @@ TEST(ParameterTests, MultipleParametersTest) {
     EXPECT_EQ(200, response.status_code);
 }
 
+TEST(ParameterTests, MultipleDynamicParametersTest) {
+    auto url = Url{base + "/hello.html"};
+    auto parameters = Parameters{{"key", "value"}};
+    parameters.AddParameter({"hello", "world"});
+    parameters.AddParameter({"test", "case"});
+    auto response = cpr::Get(url, parameters);
+    auto expected_text = std::string{"Hello world!"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(Url{url + "?key=value&hello=world&test=case"}, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+}
+
 TEST(BasicAuthenticationTests, BasicAuthenticationSuccessTest) {
     auto url = Url{base + "/basic_auth.html"};
     auto response = cpr::Get(url, Authentication{"user", "password"});


### PR DESCRIPTION
While writing an application which uses the `cpr` library I found impossible to add parameters to a request in a dynamic fashion.
For example, I have some parameters backed up in a std container, and I want to add all of them to the `cpr::Parameters` object, but I don't know the size of the container in advance.
Maybe I'm misleading something, maybe this funcionality already exists in the project, nevertheless I wasn't able to find it. Please correct me if I am wrong, but I think this simple patch can be useful.