### PR TITLE
Use fixed-size numerical types

### DIFF
--- a/cpr/error.cpp
+++ b/cpr/error.cpp
@@ -4,7 +4,7 @@
 
 namespace cpr {
 
-ErrorCode Error::getErrorCodeForCurlError(int curl_code) {
+ErrorCode Error::getErrorCodeForCurlError(std::int32_t curl_code) {
     switch (curl_code) {
         case CURLE_OK:
             return ErrorCode::OK;

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -29,7 +29,7 @@ class Session::Impl {
     void SetMultipart(Multipart&& multipart);
     void SetMultipart(const Multipart& multipart);
     void SetRedirect(const bool& redirect);
-    void SetMaxRedirects(const long& max_redirects);
+    void SetMaxRedirects(const std::int32_t& max_redirects);
     void SetCookies(const Cookies& cookies);
     void SetBody(Body&& body);
     void SetBody(const Body& body);
@@ -221,11 +221,11 @@ void Session::Impl::SetMultipart(const Multipart& multipart) {
 void Session::Impl::SetRedirect(const bool& redirect) {
     auto curl = curl_->handle;
     if (curl) {
-        curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, long(redirect));
+        curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, std::int32_t(redirect));
     }
 }
 
-void Session::Impl::SetMaxRedirects(const long& max_redirects) {
+void Session::Impl::SetMaxRedirects(const std::int32_t& max_redirects) {
     auto curl = curl_->handle;
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_MAXREDIRS, max_redirects);
@@ -352,7 +352,7 @@ Response Session::Impl::makeRequest(CURL* curl) {
     auto curl_error = curl_easy_perform(curl);
 
     char* raw_url;
-    long response_code;
+    std::int32_t response_code;
     double elapsed;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
     curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME, &elapsed);
@@ -393,7 +393,7 @@ void Session::SetProxies(Proxies&& proxies) { pimpl_->SetProxies(std::move(proxi
 void Session::SetMultipart(const Multipart& multipart) { pimpl_->SetMultipart(multipart); }
 void Session::SetMultipart(Multipart&& multipart) { pimpl_->SetMultipart(std::move(multipart)); }
 void Session::SetRedirect(const bool& redirect) { pimpl_->SetRedirect(redirect); }
-void Session::SetMaxRedirects(const long& max_redirects) { pimpl_->SetMaxRedirects(max_redirects); }
+void Session::SetMaxRedirects(const std::int32_t& max_redirects) { pimpl_->SetMaxRedirects(max_redirects); }
 void Session::SetCookies(const Cookies& cookies) { pimpl_->SetCookies(cookies); }
 void Session::SetBody(const Body& body) { pimpl_->SetBody(body); }
 void Session::SetBody(Body&& body) { pimpl_->SetBody(std::move(body)); }
@@ -411,7 +411,7 @@ void Session::SetOption(Proxies&& proxies) { pimpl_->SetProxies(std::move(proxie
 void Session::SetOption(const Multipart& multipart) { pimpl_->SetMultipart(multipart); }
 void Session::SetOption(Multipart&& multipart) { pimpl_->SetMultipart(std::move(multipart)); }
 void Session::SetOption(const bool& redirect) { pimpl_->SetRedirect(redirect); }
-void Session::SetOption(const long& max_redirects) { pimpl_->SetMaxRedirects(max_redirects); }
+void Session::SetOption(const std::int32_t& max_redirects) { pimpl_->SetMaxRedirects(max_redirects); }
 void Session::SetOption(const Cookies& cookies) { pimpl_->SetCookies(cookies); }
 void Session::SetOption(const Body& body) { pimpl_->SetBody(body); }
 void Session::SetOption(Body&& body) { pimpl_->SetBody(std::move(body)); }

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -1,6 +1,7 @@
 #include "cpr/util.h"
 
 #include <cctype>
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 #include <string>
@@ -80,7 +81,7 @@ std::string urlEncode(const std::string& value) {
             continue;
         }
         // Any other characters are percent-encoded
-        escaped << '%' << std::setw(2) << int((unsigned char) c);
+        escaped << '%' << std::setw(2) << std::int32_t((unsigned char) c);
     }
 
     return escaped.str();

--- a/include/cpr/error.h
+++ b/include/cpr/error.h
@@ -2,6 +2,7 @@
 #define CPR_ERROR_H
 
 #include <string>
+#include <cstdint>
 
 #include "cprtypes.h"
 #include "defines.h"
@@ -33,7 +34,7 @@ class Error {
     Error() : code{ErrorCode::OK} {}
 
     template <typename TextType>
-    Error(const int& curl_code, TextType&& p_error_message)
+    Error(const std::int32_t& curl_code, TextType&& p_error_message)
             : code{getErrorCodeForCurlError(curl_code)}, message{CPR_FWD(p_error_message)} {}
 
     explicit operator bool() const {
@@ -44,7 +45,7 @@ class Error {
     std::string message;
 
   private:
-    static ErrorCode getErrorCodeForCurlError(int curl_code);
+    static ErrorCode getErrorCodeForCurlError(std::int32_t curl_code);
 };
 
 } // namespace cpr

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -2,6 +2,7 @@
 #define CPR_MULTIPART_H
 
 #include <initializer_list>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -15,7 +16,7 @@ struct File {
 struct Part {
     Part(const std::string& name, const std::string& value, const std::string& content_type = {})
             : name{name}, value{value}, content_type{content_type}, is_file{false} {}
-    Part(const std::string& name, const int& value, const std::string& content_type = {})
+    Part(const std::string& name, const std::int32_t& value, const std::string& content_type = {})
             : name{name}, value{std::to_string(value)}, content_type{content_type}, is_file{false} {
     }
     Part(const std::string& name, const File& file, const std::string& content_type = {})

--- a/include/cpr/payload.h
+++ b/include/cpr/payload.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 #include <initializer_list>
 
 #include "defines.h"
@@ -15,7 +16,7 @@ struct Pair {
     Pair(KeyType&& p_key, ValueType&& p_value)
             : key{CPR_FWD(p_key)}, value{CPR_FWD(p_value)} {}
     template <typename KeyType>
-    Pair(KeyType&& p_key, const int& p_value)
+    Pair(KeyType&& p_key, const std::int32_t& p_value)
             : key{CPR_FWD(p_key)}, value{std::to_string(p_value)} {}
 
     std::string key;

--- a/include/cpr/response.h
+++ b/include/cpr/response.h
@@ -2,6 +2,7 @@
 #define CPR_RESPONSE_H
 
 #include <string>
+#include <cstdint>
 
 #include "cookies.h"
 #include "cprtypes.h"
@@ -15,14 +16,14 @@ class Response {
 
     template <typename TextType, typename HeaderType, typename UrlType, typename CookiesType,
               typename ErrorType>
-    Response(const long& p_status_code, TextType&& p_text, HeaderType&& p_header, UrlType&& p_url,
+    Response(const std::int32_t& p_status_code, TextType&& p_text, HeaderType&& p_header, UrlType&& p_url,
              const double& p_elapsed, CookiesType&& p_cookies = Cookies{},
              ErrorType&& p_error = Error{})
             : status_code{p_status_code}, text{CPR_FWD(p_text)}, header{CPR_FWD(p_header)},
               url{CPR_FWD(p_url)}, elapsed{p_elapsed}, cookies{CPR_FWD(p_cookies)},
               error{CPR_FWD(p_error)} {}
 
-    long status_code;
+    std::int32_t status_code;
     std::string text;
     Header header;
     Url url;

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -2,6 +2,7 @@
 #define CPR_SESSION_H
 
 #include <memory>
+#include <cstdint>
 
 #include "auth.h"
 #include "body.h"
@@ -36,7 +37,7 @@ class Session {
     void SetMultipart(Multipart&& multipart);
     void SetMultipart(const Multipart& multipart);
     void SetRedirect(const bool& redirect);
-    void SetMaxRedirects(const long& max_redirects);
+    void SetMaxRedirects(const std::int32_t& max_redirects);
     void SetCookies(const Cookies& cookies);
     void SetBody(Body&& body);
     void SetBody(const Body& body);
@@ -56,7 +57,7 @@ class Session {
     void SetOption(Multipart&& multipart);
     void SetOption(const Multipart& multipart);
     void SetOption(const bool& redirect);
-    void SetOption(const long& max_redirects);
+    void SetOption(const std::int32_t& max_redirects);
     void SetOption(const Cookies& cookies);
     void SetOption(Body&& body);
     void SetOption(const Body& body);

--- a/include/cpr/timeout.h
+++ b/include/cpr/timeout.h
@@ -1,13 +1,15 @@
 #ifndef CPR_TIMEOUT_H
 #define CPR_TIMEOUT_H
 
+#include <cstdint>
+
 namespace cpr {
 
 class Timeout {
   public:
-    Timeout(const long& timeout) : ms(timeout) {}
+    Timeout(const std::int32_t& timeout) : ms(timeout) {}
 
-    long ms;
+    std::int32_t ms;
 };
 
 } // namespace cpr


### PR DESCRIPTION
On x86-64 `int` and `long` are 32 bits wide, so `std::int32_t` was used

Closes https://github.com/whoshuu/cpr/issues/78