### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ int main(int argc, char** argv) {
                       cpr::Authentication{"user", "pass"},
                       cpr::Parameters{{"anon", "true"}, {"key", "value"}});
     r.status_code;                  // 200
-    r.headers["content-type"];      // application/json; charset=utf-8
+    r.header["content-type"];       // application/json; charset=utf-8
     r.text;                         // JSON text string
 }
 ```


### PR DESCRIPTION
The response does not have a `headers` member, but does have a `header` member. This is different to the python requests library, but renaming the member here to be consistent would be an API break.

Resolves #80