### PR TITLE
Add cpr::Timeout constructor with std::chrono, and store timeout dura…

### DIFF
--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(${CPR_LIBRARIES}
     payload.cpp
     proxies.cpp
     session.cpp
+    timeout.cpp
     util.cpp
 
     # Header files (useful in IDEs)

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <functional>
 #include <string>
+#include <type_traits>
 
 #include <curl/curl.h>
 
@@ -126,6 +127,8 @@ void Session::Impl::SetHeader(const Header& header) {
 void Session::Impl::SetTimeout(const Timeout& timeout) {
     auto curl = curl_->handle;
     if (curl) {
+        static_assert(std::is_same<std::chrono::milliseconds, decltype(timeout.ms)>::value,
+                      "Following casting expects milliseconds.");
         long milliseconds = timeout.ms.count();
         curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, milliseconds);
     }

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -126,7 +126,7 @@ void Session::Impl::SetHeader(const Header& header) {
 void Session::Impl::SetTimeout(const Timeout& timeout) {
     auto curl = curl_->handle;
     if (curl) {
-        curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeout.ms);
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeout.ms.count());
     }
 }
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -126,7 +126,8 @@ void Session::Impl::SetHeader(const Header& header) {
 void Session::Impl::SetTimeout(const Timeout& timeout) {
     auto curl = curl_->handle;
     if (curl) {
-        curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeout.ms.count());
+        long milliseconds = timeout.ms.count();
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, milliseconds);
     }
 }
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -2,10 +2,7 @@
 
 #include <algorithm>
 #include <functional>
-#include <limits>
-#include <stdexcept>
 #include <string>
-#include <type_traits>
 
 #include <curl/curl.h>
 
@@ -129,18 +126,7 @@ void Session::Impl::SetHeader(const Header& header) {
 void Session::Impl::SetTimeout(const Timeout& timeout) {
     auto curl = curl_->handle;
     if (curl) {
-
-        static_assert(std::is_same<std::chrono::milliseconds, decltype(timeout.ms)>::value,
-                      "Following casting expects milliseconds.");
-
-        if(timeout.ms.count() > std::numeric_limits<long>::max()) {
-            throw std::overflow_error("cpr::Timeout: timeout value overflow: " + std::to_string(timeout.ms.count()) + " ms.");
-        }
-        if(timeout.ms.count() < std::numeric_limits<long>::min()) {
-            throw std::underflow_error("cpr::Timeout: timeout value underflow: " + std::to_string(timeout.ms.count()) + " ms.");
-        }
-
-        long milliseconds = timeout.ms.count();
+        long milliseconds = timeout.Milliseconds();
         curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, milliseconds);
     }
 }

--- a/cpr/timeout.cpp
+++ b/cpr/timeout.cpp
@@ -1,0 +1,25 @@
+#include "cpr/timeout.h"
+
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+namespace cpr {
+
+long Timeout::Milliseconds() const {
+
+    static_assert(std::is_same<std::chrono::milliseconds, decltype(ms)>::value,
+                  "Following casting expects milliseconds.");
+
+    if(ms.count() > std::numeric_limits<long>::max()) {
+        throw std::overflow_error("cpr::Timeout: timeout value overflow: " + std::to_string(ms.count()) + " ms.");
+    }
+    if(ms.count() < std::numeric_limits<long>::min()) {
+        throw std::underflow_error("cpr::Timeout: timeout value underflow: " + std::to_string(ms.count()) + " ms.");
+    }
+
+    return static_cast<long>(ms.count());
+}
+
+} // namespace cpr

--- a/cpr/timeout.cpp
+++ b/cpr/timeout.cpp
@@ -8,15 +8,16 @@
 namespace cpr {
 
 long Timeout::Milliseconds() const {
-
     static_assert(std::is_same<std::chrono::milliseconds, decltype(ms)>::value,
                   "Following casting expects milliseconds.");
 
-    if(ms.count() > std::numeric_limits<long>::max()) {
-        throw std::overflow_error("cpr::Timeout: timeout value overflow: " + std::to_string(ms.count()) + " ms.");
+    if (ms.count() > std::numeric_limits<long>::max()) {
+        throw std::overflow_error("cpr::Timeout: timeout value overflow: " +
+                                  std::to_string(ms.count()) + " ms.");
     }
-    if(ms.count() < std::numeric_limits<long>::min()) {
-        throw std::underflow_error("cpr::Timeout: timeout value underflow: " + std::to_string(ms.count()) + " ms.");
+    if (ms.count() < std::numeric_limits<long>::min()) {
+        throw std::underflow_error("cpr::Timeout: timeout value underflow: " +
+                                   std::to_string(ms.count()) + " ms.");
     }
 
     return static_cast<long>(ms.count());

--- a/include/cpr/timeout.h
+++ b/include/cpr/timeout.h
@@ -12,6 +12,8 @@ class Timeout {
     Timeout(const std::int32_t& milliseconds)
             : Timeout{std::chrono::milliseconds(milliseconds)} {}
 
+    long Milliseconds() const;
+
     std::chrono::milliseconds ms;
 };
 

--- a/include/cpr/timeout.h
+++ b/include/cpr/timeout.h
@@ -1,23 +1,14 @@
 #ifndef CPR_TIMEOUT_H
 #define CPR_TIMEOUT_H
 
-#include <cstdint>
 #include <chrono>
-#include <limits>
-#include <stdexcept>
+#include <cstdint>
 
 namespace cpr {
 
 class Timeout {
   public:
-    Timeout(const std::chrono::milliseconds& duration) : ms{duration} {
-        if(ms.count() > std::numeric_limits<long>::max()) {
-            throw std::overflow_error("cpr::Timeout: timeout value overflow.");
-        }
-        if(ms.count() < std::numeric_limits<long>::min()) {
-            throw std::underflow_error("cpr::Timeout: timeout value underflow.");
-        }
-    }
+    Timeout(const std::chrono::milliseconds& duration) : ms{duration} {}
     Timeout(const std::int32_t& milliseconds)
             : Timeout{std::chrono::milliseconds(milliseconds)} {}
 

--- a/include/cpr/timeout.h
+++ b/include/cpr/timeout.h
@@ -3,13 +3,23 @@
 
 #include <cstdint>
 #include <chrono>
+#include <limits>
+#include <stdexcept>
 
 namespace cpr {
 
 class Timeout {
   public:
-    Timeout(const std::chrono::milliseconds& timeout) : ms(timeout) {}
-    Timeout(const std::int32_t& timeout) : ms(timeout) {}
+    Timeout(const std::chrono::milliseconds& duration) : ms{duration} {
+        if(ms.count() > std::numeric_limits<long>::max()) {
+            throw std::overflow_error("cpr::Timeout: timeout value overflow.");
+        }
+        if(ms.count() < std::numeric_limits<long>::min()) {
+            throw std::underflow_error("cpr::Timeout: timeout value underflow.");
+        }
+    }
+    Timeout(const std::int32_t& milliseconds)
+            : Timeout{std::chrono::milliseconds(milliseconds)} {}
 
     std::chrono::milliseconds ms;
 };

--- a/include/cpr/timeout.h
+++ b/include/cpr/timeout.h
@@ -2,14 +2,16 @@
 #define CPR_TIMEOUT_H
 
 #include <cstdint>
+#include <chrono>
 
 namespace cpr {
 
 class Timeout {
   public:
+    Timeout(const std::chrono::milliseconds& timeout) : ms(timeout) {}
     Timeout(const std::int32_t& timeout) : ms(timeout) {}
 
-    std::int32_t ms;
+    std::chrono::milliseconds ms;
 };
 
 } // namespace cpr


### PR DESCRIPTION
…tion as std::chrono::milliseconds.

Since C++11 has standard tools to manage timepoints and durations, it's looks much more natural to setup timeout in `std::chrono::milliseconds`, or seconds, or minutes (they cast down transparently) or as difference between two timepoints or durations. And makes it totally clear which time measurement is used.

Modification is trivial and very straightforward. Only one remark: `curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeout)` expect last argument to be `long`, but `std::chrono::milliseconds::count()` return `int64_t`, so there could be some problems, if somebody will decide set timeout longer than 24 days and 20 hours (=2'147'483 seconds).