### PR TITLE
Make response_code long as suggested by CURL documentation

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -352,7 +352,7 @@ Response Session::Impl::makeRequest(CURL* curl) {
     auto curl_error = curl_easy_perform(curl);
 
     char* raw_url;
-    std::int32_t response_code;
+    std::int64_t response_code;
     double elapsed;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
     curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME, &elapsed);

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -352,7 +352,7 @@ Response Session::Impl::makeRequest(CURL* curl) {
     auto curl_error = curl_easy_perform(curl);
 
     char* raw_url;
-    std::int64_t response_code;
+    long response_code;
     double elapsed;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
     curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME, &elapsed);
@@ -373,7 +373,8 @@ Response Session::Impl::makeRequest(CURL* curl) {
 
     auto header = cpr::util::parseHeader(header_string);
     response_string = cpr::util::parseResponse(response_string);
-    return Response{response_code, response_string, header, raw_url, elapsed, cookies, error};
+    return Response{static_cast<std::int32_t>(response_code),
+        response_string, header, raw_url, elapsed, cookies, error};
 }
 
 // clang-format off

--- a/include/cpr/response.h
+++ b/include/cpr/response.h
@@ -16,14 +16,14 @@ class Response {
 
     template <typename TextType, typename HeaderType, typename UrlType, typename CookiesType,
               typename ErrorType>
-    Response(const std::int32_t& p_status_code, TextType&& p_text, HeaderType&& p_header, UrlType&& p_url,
+    Response(const std::int64_t& p_status_code, TextType&& p_text, HeaderType&& p_header, UrlType&& p_url,
              const double& p_elapsed, CookiesType&& p_cookies = Cookies{},
              ErrorType&& p_error = Error{})
             : status_code{p_status_code}, text{CPR_FWD(p_text)}, header{CPR_FWD(p_header)},
               url{CPR_FWD(p_url)}, elapsed{p_elapsed}, cookies{CPR_FWD(p_cookies)},
               error{CPR_FWD(p_error)} {}
 
-    std::int32_t status_code;
+    std::int64_t status_code;
     std::string text;
     Header header;
     Url url;

--- a/include/cpr/response.h
+++ b/include/cpr/response.h
@@ -16,14 +16,14 @@ class Response {
 
     template <typename TextType, typename HeaderType, typename UrlType, typename CookiesType,
               typename ErrorType>
-    Response(const std::int64_t& p_status_code, TextType&& p_text, HeaderType&& p_header, UrlType&& p_url,
+    Response(const std::int32_t& p_status_code, TextType&& p_text, HeaderType&& p_header, UrlType&& p_url,
              const double& p_elapsed, CookiesType&& p_cookies = Cookies{},
              ErrorType&& p_error = Error{})
             : status_code{p_status_code}, text{CPR_FWD(p_text)}, header{CPR_FWD(p_header)},
               url{CPR_FWD(p_url)}, elapsed{p_elapsed}, cookies{CPR_FWD(p_cookies)},
               error{CPR_FWD(p_error)} {}
 
-    std::int64_t status_code;
+    std::int32_t status_code;
     std::string text;
     Header header;
     Url url;


### PR DESCRIPTION
Fixes #93, response_code should be a long according to
https://curl.haxx.se/libcurl/c/curl_easy_getinfo.html. Before this
commit it was a std::int32_t. In g++ this caused the call to
curl_easy_getinfo to overwrite curl_error and set it to 0 which made the
BadHost tests fail.

