### PR TITLE
Allow sending a body in a DELETE requests

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -67,6 +67,7 @@ Session::Impl::Impl() {
         curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 50L);
         curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_->error);
         curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 0L);
 #ifdef INSECURE_CURL
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -260,7 +260,7 @@ Response Session::Impl::Delete() {
     auto curl = curl_->handle;
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_HTTPGET, 0L);
-        curl_easy_setopt(curl, CURLOPT_POST, 0L);
+        curl_easy_setopt(curl, CURLOPT_POST, 1L);
         curl_easy_setopt(curl, CURLOPT_NOBODY, 0L);
         curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
     }

--- a/test/delete_tests.cpp
+++ b/test/delete_tests.cpp
@@ -33,6 +33,17 @@ TEST(DeleteTests, DeleteUnallowedTest) {
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
 
+TEST(DeleteTests, DeleteJsonBodyTest) {
+    auto url = Url{base + "/delete.html"};
+    auto response = cpr::Delete(url, cpr::Body{"'foo': 'bar'"}, cpr::Header{{"Content-Type", "application/json"}});
+    auto expected_text = std::string{"'foo': 'bar'"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
 TEST(DeleteTests, SessionDeleteTest) {
     auto url = Url{base + "/delete.html"};
     Session session;
@@ -56,6 +67,21 @@ TEST(DeleteTests, SessionDeleteUnallowedTest) {
     EXPECT_EQ(url, response.url);
     EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
     EXPECT_EQ(405, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(DeleteTests, SessionDeleteJsonBodyTest) {
+    auto url = Url{base + "/delete.html"};
+    Session session;
+    session.SetUrl(url);
+    session.SetHeader(cpr::Header{{"Content-Type", "application/json"}});
+    session.SetBody(cpr::Body{"{'foo': 'bar'}"});
+    auto response = session.Delete();
+    auto expected_text = std::string{"{'foo': 'bar'}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
 

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -363,7 +363,7 @@ static int deleteRequest(struct mg_connection* conn) {
       } else {
           auto response = std::string{conn->content, conn->content_len};
           mg_send_status(conn, 200);
-          mg_send_header(conn, "content-type", "text/html");
+          mg_send_header(conn, "content-type", "application/json");
           mg_send_data(conn, response.data(), response.length());
       }
     } else {

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -344,11 +344,28 @@ static int formPost(struct mg_connection* conn) {
 }
 
 static int deleteRequest(struct mg_connection* conn) {
+    auto num_headers = conn->num_headers;
+    auto headers = conn->http_headers;
+    auto has_json_header = false;
+    for (int i = 0; i < num_headers; ++i) {
+        auto name = headers[i].name;
+        if (std::string{"Content-Type"} == headers[i].name &&
+                std::string{"application/json"} == headers[i].value) {
+            has_json_header = true;
+        }
+    }
     if (std::string{conn->request_method} == std::string{"DELETE"}) {
-        auto response = std::string{"Delete success"};
-        mg_send_status(conn, 200);
-        mg_send_header(conn, "content-type", "text/html");
-        mg_send_data(conn, response.data(), response.length());
+      if (!has_json_header) {
+          auto response = std::string{"Delete success"};
+          mg_send_status(conn, 200);
+          mg_send_header(conn, "content-type", "text/html");
+          mg_send_data(conn, response.data(), response.length());
+      } else {
+          auto response = std::string{conn->content, conn->content_len};
+          mg_send_status(conn, 200);
+          mg_send_header(conn, "content-type", "text/html");
+          mg_send_data(conn, response.data(), response.length());
+      }
     } else {
         auto response = std::string{"Method unallowed"};
         mg_send_status(conn, 405);


### PR DESCRIPTION
Currently payload set in the body is silently dropped, when a DELETE requests is sent.
For example
`cpr::Delete(cpr::Url{URL},cpr::Body{"'foo': 'bar'"}, cpr::Header{{"Content-Type", "application/json"}});`
will send a DELETE requests without the body.
With this change the body will be transferred.