### PR TITLE
Build option to disable use of signals in curl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ cpr_option(USE_SYSTEM_CURL
 cpr_option(BUILD_CPR_TESTS "Set to ON to build cpr tests." ON)
 cpr_option(INSECURE_CURL "Set to ON to disable verification of SSL certificates." OFF)
 cpr_option(GENERATE_COVERAGE "Set to ON to generate coverage reports." OFF)
+cpr_option(CPR_CURL_NOSIGNAL "Set to ON to disable use of signals in libcurl." OFF)
 cpr_option(USE_SYSTEM_GTEST
     "If ON, this project will look in the system paths for an installed gtest library" OFF)
 cpr_option(CMAKE_USE_OPENSSL "Use OpenSSL code. Experimental" ON)

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -67,6 +67,9 @@ Session::Impl::Impl() {
         curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 50L);
         curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_->error);
         curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
+#ifdef CPR_CURL_NOSIGNAL
+        curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+#endif
 #ifdef INSECURE_CURL
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);


### PR DESCRIPTION
Curl sometimes segfaults on linux if used in a multithreaded program due to the use of signals. This is already discussed in issue #74.

This commit adds a build option to disable the use of signals by Curl.