### PR TITLE
Add LowSpeed option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ C++ Requests currently supports:
 * Basic authentication
 * Digest authentication
 * Timeout specification
+* Timeout for low speed connection
 * Asynchronous requests
 * :cookie: support!
 * Proxy support

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -33,6 +33,7 @@ class Session::Impl {
     void SetCookies(const Cookies& cookies);
     void SetBody(Body&& body);
     void SetBody(const Body& body);
+    void SetLowSpeed(const LowSpeed& low_speed);
 
     Response Delete();
     Response Get();
@@ -256,6 +257,15 @@ void Session::Impl::SetBody(const Body& body) {
     }
 }
 
+void Session::Impl::SetLowSpeed(const LowSpeed& low_speed)
+{
+    auto curl = curl_->handle;
+    if (curl) {
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, low_speed.limit);
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, low_speed.time);
+    }
+}
+
 Response Session::Impl::Delete() {
     auto curl = curl_->handle;
     if (curl) {
@@ -399,6 +409,7 @@ void Session::SetMaxRedirects(const MaxRedirects& max_redirects) { pimpl_->SetMa
 void Session::SetCookies(const Cookies& cookies) { pimpl_->SetCookies(cookies); }
 void Session::SetBody(const Body& body) { pimpl_->SetBody(body); }
 void Session::SetBody(Body&& body) { pimpl_->SetBody(std::move(body)); }
+void Session::SetLowSpeed(const LowSpeed& low_speed) { pimpl_->SetLowSpeed(low_speed); }
 void Session::SetOption(const Url& url) { pimpl_->SetUrl(url); }
 void Session::SetOption(const Parameters& parameters) { pimpl_->SetParameters(parameters); }
 void Session::SetOption(Parameters&& parameters) { pimpl_->SetParameters(std::move(parameters)); }
@@ -417,6 +428,7 @@ void Session::SetOption(const MaxRedirects& max_redirects) { pimpl_->SetMaxRedir
 void Session::SetOption(const Cookies& cookies) { pimpl_->SetCookies(cookies); }
 void Session::SetOption(const Body& body) { pimpl_->SetBody(body); }
 void Session::SetOption(Body&& body) { pimpl_->SetBody(std::move(body)); }
+void Session::SetOption(const LowSpeed& low_speed) { pimpl_->SetLowSpeed(low_speed); }
 Response Session::Delete() { return pimpl_->Delete(); }
 Response Session::Get() { return pimpl_->Get(); }
 Response Session::Head() { return pimpl_->Head(); }

--- a/include/cpr/low_speed.h
+++ b/include/cpr/low_speed.h
@@ -1,0 +1,18 @@
+#ifndef CPR_LOW_SPEED_H
+#define CPR_LOW_SPEED_H
+
+#include <cstdint>
+
+namespace cpr {
+
+class LowSpeed {
+  public:
+    LowSpeed(const std::int32_t& limit, const std::int32_t& time) : limit(limit), time(time) {}
+
+    std::int32_t limit;
+    std::int32_t time;
+};
+
+} // namespace cpr
+
+#endif

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -16,6 +16,7 @@
 #include "proxies.h"
 #include "response.h"
 #include "timeout.h"
+#include "low_speed.h"
 
 namespace cpr {
 
@@ -42,6 +43,7 @@ class Session {
     void SetCookies(const Cookies& cookies);
     void SetBody(Body&& body);
     void SetBody(const Body& body);
+    void SetLowSpeed(const LowSpeed& low_speed);
 
     // Used in templated functions
     void SetOption(const Url& url);
@@ -62,6 +64,7 @@ class Session {
     void SetOption(const Cookies& cookies);
     void SetOption(Body&& body);
     void SetOption(const Body& body);
+    void SetOption(const LowSpeed& low_speed);
 
     Response Delete();
     Response Get();

--- a/test/error_tests.cpp
+++ b/test/error_tests.cpp
@@ -48,6 +48,13 @@ TEST(ErrorTests, TimeoutFailure) {
     EXPECT_EQ(ErrorCode::OPERATION_TIMEDOUT, response.error.code);
 }
 
+TEST(ErrorTests, LowSpeedFailure) {
+    auto url = Url{base + "/low_speed.html"};
+    auto response = cpr::Get(url, cpr::LowSpeed{1000, 1});
+    EXPECT_EQ(0, response.status_code);
+    EXPECT_EQ(ErrorCode::OPERATION_TIMEDOUT, response.error.code);
+}
+
 TEST(ErrorTests, ProxyFailure) {
     auto url = Url{base + "/hello.html"};
     auto response = cpr::Get(url, cpr::Proxies{{"http", "http://bad_host/"}});

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -74,6 +74,15 @@ static int timeout(struct mg_connection* conn) {
     return MG_TRUE;
 }
 
+static int lowSpeed(struct mg_connection* conn) {
+    auto response = std::string{"Hello world!"};
+    mg_send_status(conn, 200);
+    mg_send_header(conn, "content-type", "text/html");
+    std::this_thread::sleep_for(std::chrono::seconds(8));
+    mg_send_data(conn, response.data(), response.length());
+    return MG_TRUE;
+}
+
 static int basicCookies(struct mg_connection* conn) {
     auto response = std::string{"Hello world!"};
     mg_send_status(conn, 200);
@@ -487,6 +496,8 @@ static int evHandler(struct mg_connection* conn, enum mg_event ev) {
                 return hello(conn);
             } else if (Url{conn->uri} == "/timeout.html") {
                 return timeout(conn);
+            } else if (Url{conn->uri} == "/low_speed.html") {
+                return lowSpeed(conn);				
             } else if (Url{conn->uri} == "/basic_cookies.html") {
                 return basicCookies(conn);
             } else if (Url{conn->uri} == "/check_cookies.html") {


### PR DESCRIPTION
Sometimes it could be convinient to use CURL options CURLOPT_LOW_SPEED_LIMIT/CURLOPT_LOW_SPEED_TIME instead CURLOPT_TIMEOUT_MS. For example, when you don't know how many bytes can be transferred.
This commit adds a LowSpeed option to define these two CURL options.
Also, an appropriate test has been added to error_tests.cpp.