### PR TITLE
Add support for NTLM authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ C++ Requests currently supports:
 * File POST upload
 * Basic authentication
 * Digest authentication
+* NTLM authentication
 * Connection and request timeout specification
 * Timeout for low speed connection
 * Asynchronous requests

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(${CPR_LIBRARIES}
     digest.cpp
     error.cpp
     multipart.cpp
+    ntlm.cpp
     parameters.cpp
     payload.cpp
     proxies.cpp
@@ -30,6 +31,7 @@ add_library(${CPR_LIBRARIES}
     "${CPR_INCLUDE_DIRS}/cpr/error.h"
     "${CPR_INCLUDE_DIRS}/cpr/max_redirects.h"
     "${CPR_INCLUDE_DIRS}/cpr/multipart.h"
+    "${CPR_INCLUDE_DIRS}/cpr/ntlm.h"
     "${CPR_INCLUDE_DIRS}/cpr/parameters.h"
     "${CPR_INCLUDE_DIRS}/cpr/payload.h"
     "${CPR_INCLUDE_DIRS}/cpr/proxies.h"

--- a/cpr/ntlm.cpp
+++ b/cpr/ntlm.cpp
@@ -1,0 +1,9 @@
+#include "cpr/ntlm.h"
+
+namespace cpr {
+
+const char* NTLM::GetAuthString() const noexcept {
+    return Authentication::GetAuthString();
+}
+
+} // namespace cpr

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -35,6 +35,7 @@ class Session::Impl {
     void SetProxies(const Proxies& proxies);
     void SetMultipart(Multipart&& multipart);
     void SetMultipart(const Multipart& multipart);
+    void SetNTLM(const NTLM& auth);
     void SetRedirect(const bool& redirect);
     void SetMaxRedirects(const MaxRedirects& max_redirects);
     void SetCookies(const Cookies& cookies);
@@ -290,6 +291,14 @@ void Session::Impl::SetLimitRate(const LimitRate& limit_rate) {
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_MAX_RECV_SPEED_LARGE, limit_rate.downrate);
         curl_easy_setopt(curl, CURLOPT_MAX_SEND_SPEED_LARGE, limit_rate.uprate);
+    }
+}
+
+void Session::Impl::SetNTLM(const NTLM& auth) {
+    auto curl = curl_->handle;
+    if (curl) {
+        curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
+        curl_easy_setopt(curl, CURLOPT_USERPWD, auth.GetAuthString());
     }
 }
 
@@ -628,6 +637,7 @@ void Session::SetProxies(const Proxies& proxies) { pimpl_->SetProxies(proxies); 
 void Session::SetProxies(Proxies&& proxies) { pimpl_->SetProxies(std::move(proxies)); }
 void Session::SetMultipart(const Multipart& multipart) { pimpl_->SetMultipart(multipart); }
 void Session::SetMultipart(Multipart&& multipart) { pimpl_->SetMultipart(std::move(multipart)); }
+void Session::SetNTLM(const NTLM& auth) { pimpl_->SetNTLM(auth); }
 void Session::SetRedirect(const bool& redirect) { pimpl_->SetRedirect(redirect); }
 void Session::SetMaxRedirects(const MaxRedirects& max_redirects) { pimpl_->SetMaxRedirects(max_redirects); }
 void Session::SetCookies(const Cookies& cookies) { pimpl_->SetCookies(cookies); }
@@ -650,6 +660,7 @@ void Session::SetOption(const Proxies& proxies) { pimpl_->SetProxies(proxies); }
 void Session::SetOption(Proxies&& proxies) { pimpl_->SetProxies(std::move(proxies)); }
 void Session::SetOption(const Multipart& multipart) { pimpl_->SetMultipart(multipart); }
 void Session::SetOption(Multipart&& multipart) { pimpl_->SetMultipart(std::move(multipart)); }
+void Session::SetOption(const NTLM& auth) { pimpl_->SetNTLM(auth); }
 void Session::SetOption(const bool& redirect) { pimpl_->SetRedirect(redirect); }
 void Session::SetOption(const MaxRedirects& max_redirects) { pimpl_->SetMaxRedirects(max_redirects); }
 void Session::SetOption(const Cookies& cookies) { pimpl_->SetCookies(cookies); }

--- a/include/cpr/api.h
+++ b/include/cpr/api.h
@@ -11,6 +11,7 @@
 #include "cpr/defines.h"
 #include "cpr/digest.h"
 #include "cpr/multipart.h"
+#include "cpr/ntlm.h"
 #include "cpr/payload.h"
 #include "cpr/response.h"
 #include "cpr/session.h"

--- a/include/cpr/ntlm.h
+++ b/include/cpr/ntlm.h
@@ -1,0 +1,20 @@
+#ifndef CPR_NTLM_H
+#define CPR_NTLM_H
+
+#include "auth.h"
+#include "defines.h"
+
+namespace cpr {
+
+class NTLM : public Authentication {
+  public:
+    template <typename UserType, typename PassType>
+    NTLM(UserType&& username, PassType&& password)
+            : Authentication{CPR_FWD(username), CPR_FWD(password)} {}
+
+    const char* GetAuthString() const noexcept;
+};
+
+} // namespace cpr
+
+#endif

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -15,6 +15,7 @@
 #include "cpr/low_speed.h"
 #include "cpr/max_redirects.h"
 #include "cpr/multipart.h"
+#include "cpr/ntlm.h"
 #include "cpr/parameters.h"
 #include "cpr/payload.h"
 #include "cpr/proxies.h"
@@ -50,6 +51,7 @@ class Session {
     void SetProxies(const Proxies& proxies);
     void SetMultipart(Multipart&& multipart);
     void SetMultipart(const Multipart& multipart);
+    void SetNTLM(const NTLM& auth);
     void SetRedirect(const bool& redirect);
     void SetMaxRedirects(const MaxRedirects& max_redirects);
     void SetCookies(const Cookies& cookies);
@@ -78,6 +80,7 @@ class Session {
     void SetOption(const Proxies& proxies);
     void SetOption(Multipart&& multipart);
     void SetOption(const Multipart& multipart);
+    void SetOption(const NTLM& auth);
     void SetOption(const bool& redirect);
     void SetOption(const MaxRedirects& max_redirects);
     void SetOption(const Cookies& cookies);


### PR DESCRIPTION
Some Windows-based servers only support NTLM authentication and don't work with the more standard types.  This patch adds support for NTLM auth so that cpr can be used to interact with these servers.
