### PR TITLE
Issue 128 - fix memory leak in multipart form

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -180,17 +180,40 @@ void Session::Impl::SetMultipart(Multipart&& multipart) {
         struct curl_httppost* lastptr = NULL;
 
         for (auto& part : multipart.parts) {
-            auto content_option = CURLFORM_COPYCONTENTS;
-            if (part.is_file) {
-                content_option = CURLFORM_FILE;
-            }
-            if (part.content_type.empty()) {
-                curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, part.name.data(),
-                             content_option, part.value.data(), CURLFORM_END);
+            if (part.is_buffer) {
+                if (part.content_type.empty()) {
+                    curl_formadd(&formpost, &lastptr,
+                                 CURLFORM_COPYNAME, part.name.data(),
+                                 CURLFORM_BUFFER, part.value.data(),
+                                 CURLFORM_BUFFERPTR, part.data,
+                                 CURLFORM_BUFFERLENGTH, part.datalen,
+                                 CURLFORM_END);
+                } else {
+                    curl_formadd(&formpost, &lastptr,
+                                 CURLFORM_COPYNAME, part.name.data(),
+                                 CURLFORM_BUFFER, part.value.data(),
+                                 CURLFORM_BUFFERPTR, part.data,
+                                 CURLFORM_BUFFERLENGTH, part.datalen,
+                                 CURLFORM_CONTENTTYPE, part.content_type.data(),
+                                 CURLFORM_END);
+                }
             } else {
-                curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, part.name.data(),
-                             content_option, part.value.data(), CURLFORM_CONTENTTYPE,
-                             part.content_type.data(), CURLFORM_END);
+                auto content_option = CURLFORM_COPYCONTENTS;
+                if (part.is_file) {
+                    content_option = CURLFORM_FILE;
+                }
+                if (part.content_type.empty()) {
+                    curl_formadd(&formpost, &lastptr,
+                                 CURLFORM_COPYNAME, part.name.data(),
+                                 content_option, part.value.data(),
+                                 CURLFORM_END);
+                } else {
+                    curl_formadd(&formpost, &lastptr,
+                                 CURLFORM_COPYNAME, part.name.data(),
+                                 content_option, part.value.data(),
+                                 CURLFORM_CONTENTTYPE, part.content_type.data(),
+                                 CURLFORM_END);
+                }
             }
         }
         curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
@@ -204,17 +227,40 @@ void Session::Impl::SetMultipart(const Multipart& multipart) {
         struct curl_httppost* lastptr = NULL;
 
         for (auto& part : multipart.parts) {
-            auto content_option = CURLFORM_PTRCONTENTS;
-            if (part.is_file) {
-                content_option = CURLFORM_FILE;
-            }
-            if (part.content_type.empty()) {
-                curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, part.name.data(),
-                             content_option, part.value.data(), CURLFORM_END);
+            if (part.is_buffer) {
+                if (part.content_type.empty()) {
+                    curl_formadd(&formpost, &lastptr,
+                                 CURLFORM_COPYNAME, part.name.data(),
+                                 CURLFORM_BUFFER, part.value.data(),
+                                 CURLFORM_BUFFERPTR, part.data,
+                                 CURLFORM_BUFFERLENGTH, part.datalen,
+                                 CURLFORM_END);
+                } else {
+                    curl_formadd(&formpost, &lastptr,
+                                 CURLFORM_COPYNAME, part.name.data(),
+                                 CURLFORM_BUFFER, part.value.data(),
+                                 CURLFORM_BUFFERPTR, part.data,
+                                 CURLFORM_BUFFERLENGTH, part.datalen,
+                                 CURLFORM_CONTENTTYPE, part.content_type.data(),
+                                 CURLFORM_END);
+                }
             } else {
-                curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, part.name.data(),
-                             content_option, part.value.data(), CURLFORM_CONTENTTYPE,
-                             part.content_type.data(), CURLFORM_END);
+                auto content_option = CURLFORM_COPYCONTENTS;
+                if (part.is_file) {
+                    content_option = CURLFORM_FILE;
+                }
+                if (part.content_type.empty()) {
+                    curl_formadd(&formpost, &lastptr,
+                                 CURLFORM_COPYNAME, part.name.data(),
+                                 content_option, part.value.data(),
+                                 CURLFORM_END);
+                } else {
+                    curl_formadd(&formpost, &lastptr,
+                                 CURLFORM_COPYNAME, part.name.data(),
+                                 content_option, part.value.data(),
+                                 CURLFORM_CONTENTTYPE, part.content_type.data(),
+                                 CURLFORM_END);
+                }
             }
         }
         curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -180,41 +180,24 @@ void Session::Impl::SetMultipart(Multipart&& multipart) {
         struct curl_httppost* lastptr = NULL;
 
         for (auto& part : multipart.parts) {
+            std::vector<struct curl_forms> formdata;
+            formdata.push_back({CURLFORM_COPYNAME, part.name.data()});
             if (part.is_buffer) {
-                if (part.content_type.empty()) {
-                    curl_formadd(&formpost, &lastptr,
-                                 CURLFORM_COPYNAME, part.name.data(),
-                                 CURLFORM_BUFFER, part.value.data(),
-                                 CURLFORM_BUFFERPTR, part.data,
-                                 CURLFORM_BUFFERLENGTH, part.datalen,
-                                 CURLFORM_END);
-                } else {
-                    curl_formadd(&formpost, &lastptr,
-                                 CURLFORM_COPYNAME, part.name.data(),
-                                 CURLFORM_BUFFER, part.value.data(),
-                                 CURLFORM_BUFFERPTR, part.data,
-                                 CURLFORM_BUFFERLENGTH, part.datalen,
-                                 CURLFORM_CONTENTTYPE, part.content_type.data(),
-                                 CURLFORM_END);
-                }
+              formdata.push_back({CURLFORM_BUFFER, part.value.data()});
+              formdata.push_back({CURLFORM_BUFFERPTR, (const char *)part.data});
+              formdata.push_back({CURLFORM_BUFFERLENGTH, (const char *)part.datalen});
+            } else if (part.is_file) {
+              formdata.push_back({CURLFORM_FILE, part.value.data()});
             } else {
-                auto content_option = CURLFORM_COPYCONTENTS;
-                if (part.is_file) {
-                    content_option = CURLFORM_FILE;
-                }
-                if (part.content_type.empty()) {
-                    curl_formadd(&formpost, &lastptr,
-                                 CURLFORM_COPYNAME, part.name.data(),
-                                 content_option, part.value.data(),
-                                 CURLFORM_END);
-                } else {
-                    curl_formadd(&formpost, &lastptr,
-                                 CURLFORM_COPYNAME, part.name.data(),
-                                 content_option, part.value.data(),
-                                 CURLFORM_CONTENTTYPE, part.content_type.data(),
-                                 CURLFORM_END);
-                }
+              formdata.push_back({CURLFORM_COPYCONTENTS, part.value.data()});
             }
+            if (!part.content_type.empty()) {
+              formdata.push_back({CURLFORM_CONTENTTYPE, part.content_type.data()});
+            }
+            formdata.push_back({CURLFORM_END, nullptr});
+            curl_formadd(&formpost, &lastptr,
+                         CURLFORM_ARRAY, formdata.data(),
+                         CURLFORM_END);
         }
         curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
     }
@@ -227,41 +210,24 @@ void Session::Impl::SetMultipart(const Multipart& multipart) {
         struct curl_httppost* lastptr = NULL;
 
         for (auto& part : multipart.parts) {
+            std::vector<struct curl_forms> formdata;
+            formdata.push_back({CURLFORM_COPYNAME, part.name.data()});
             if (part.is_buffer) {
-                if (part.content_type.empty()) {
-                    curl_formadd(&formpost, &lastptr,
-                                 CURLFORM_COPYNAME, part.name.data(),
-                                 CURLFORM_BUFFER, part.value.data(),
-                                 CURLFORM_BUFFERPTR, part.data,
-                                 CURLFORM_BUFFERLENGTH, part.datalen,
-                                 CURLFORM_END);
-                } else {
-                    curl_formadd(&formpost, &lastptr,
-                                 CURLFORM_COPYNAME, part.name.data(),
-                                 CURLFORM_BUFFER, part.value.data(),
-                                 CURLFORM_BUFFERPTR, part.data,
-                                 CURLFORM_BUFFERLENGTH, part.datalen,
-                                 CURLFORM_CONTENTTYPE, part.content_type.data(),
-                                 CURLFORM_END);
-                }
+              formdata.push_back({CURLFORM_BUFFER, part.value.data()});
+              formdata.push_back({CURLFORM_BUFFERPTR, (const char *)part.data});
+              formdata.push_back({CURLFORM_BUFFERLENGTH, (const char *)part.datalen});
+            } else if (part.is_file) {
+              formdata.push_back({CURLFORM_FILE, part.value.data()});
             } else {
-                auto content_option = CURLFORM_COPYCONTENTS;
-                if (part.is_file) {
-                    content_option = CURLFORM_FILE;
-                }
-                if (part.content_type.empty()) {
-                    curl_formadd(&formpost, &lastptr,
-                                 CURLFORM_COPYNAME, part.name.data(),
-                                 content_option, part.value.data(),
-                                 CURLFORM_END);
-                } else {
-                    curl_formadd(&formpost, &lastptr,
-                                 CURLFORM_COPYNAME, part.name.data(),
-                                 content_option, part.value.data(),
-                                 CURLFORM_CONTENTTYPE, part.content_type.data(),
-                                 CURLFORM_END);
-                }
+              formdata.push_back({CURLFORM_COPYCONTENTS, part.value.data()});
             }
+            if (!part.content_type.empty()) {
+              formdata.push_back({CURLFORM_CONTENTTYPE, part.content_type.data()});
+            }
+            formdata.push_back({CURLFORM_END, nullptr});
+            curl_formadd(&formpost, &lastptr,
+                         CURLFORM_ARRAY, formdata.data(),
+                         CURLFORM_END);
         }
         curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost);
     }

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -16,19 +16,40 @@ struct File {
     std::string filepath;
 };
 
+struct Buffer {
+    typedef const unsigned char* data_t;
+
+    template <typename Iterator, typename StringType>
+    explicit Buffer(Iterator begin, Iterator end, StringType&& filename)
+            : data{reinterpret_cast<data_t>(&(*begin))},
+              datalen{static_cast<unsigned long>(std::distance(begin, end))},
+              filename{CPR_FWD(filename)} {
+            static_assert(sizeof(*begin) == 1, "only byte buffers can be used");
+    }
+
+    data_t data;
+    unsigned long datalen;
+    std::string filename;
+};
+
 struct Part {
     Part(const std::string& name, const std::string& value, const std::string& content_type = {})
-            : name{name}, value{value}, content_type{content_type}, is_file{false} {}
+            : name{name}, value{value}, content_type{content_type}, is_file{false}, is_buffer{false} {}
     Part(const std::string& name, const std::int32_t& value, const std::string& content_type = {})
-            : name{name}, value{std::to_string(value)}, content_type{content_type}, is_file{false} {
+            : name{name}, value{std::to_string(value)}, content_type{content_type}, is_file{false}, is_buffer{false} {
     }
     Part(const std::string& name, const File& file, const std::string& content_type = {})
-            : name{name}, value{file.filepath}, content_type{content_type}, is_file{true} {}
+            : name{name}, value{file.filepath}, content_type{content_type}, is_file{true}, is_buffer{false} {}
+    Part(const std::string& name, const Buffer& buffer, const std::string& content_type = {})
+            : name{name}, value{buffer.filename}, data{buffer.data}, datalen{buffer.datalen}, content_type{content_type}, is_file{false}, is_buffer{true} {}
 
     std::string name;
     std::string value;
     std::string content_type;
     bool is_file;
+    bool is_buffer;
+    Buffer::data_t data;
+    unsigned long datalen;
 };
 
 class Multipart {

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -168,6 +168,78 @@ TEST(UrlEncodedPostTests, FormPostFileNoCopyTest) {
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
 
+TEST(UrlEncodedPostTests, FormPostFileBufferTest) {
+    auto content = std::string{"hello world"};
+    auto url = Url{base + "/form_post.html"};
+    auto response = cpr::Post(url, Multipart{{"x", Buffer{content.begin(), content.end(), "test_file"}}});
+    auto expected_text = std::string{"{\n"
+                                     "  \"x\": " + content + "\n"
+                                     "}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(UrlEncodedPostTests, FormPostFileBufferNoCopyTest) {
+    auto content = std::string{"hello world"};
+    auto url = Url{base + "/form_post.html"};
+    auto multipart = Multipart{{"x", Buffer{content.begin(), content.end(), "test_file"}}};
+    auto response = cpr::Post(url, multipart);
+    auto expected_text = std::string{"{\n"
+                                     "  \"x\": " + content + "\n"
+                                     "}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(UrlEncodedPostTests, FormPostFileBufferPointerTest) {
+    const char *content = "hello world";
+    auto url = Url{base + "/form_post.html"};
+    auto response = cpr::Post(url, Multipart{{"x", Buffer{content, 11 + content, "test_file"}}});
+    auto expected_text = std::string{"{\n"
+                                     "  \"x\": " + std::string(content) + "\n"
+                                     "}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(UrlEncodedPostTests, FormPostFileBufferArrayTest) {
+    const char content[] = "hello world";
+    auto url = Url{base + "/form_post.html"};
+    // We subtract 1 from std::end() because we don't want to include the terminating null
+    auto response = cpr::Post(url, Multipart{{"x", Buffer{std::begin(content), std::end(content)-1, "test_file"}}});
+    auto expected_text = std::string{"{\n"
+                                     "  \"x\": " + std::string(content) + "\n"
+                                     "}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(UrlEncodedPostTests, FormPostFileBufferVectorTest) {
+    std::vector<unsigned char> content{'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'};
+    auto url = Url{base + "/form_post.html"};
+    auto response = cpr::Post(url, Multipart{{"x", Buffer{content.begin(), content.end(), "test_file"}}});
+    auto expected_text = std::string{"{\n"
+                                     "  \"x\": hello world\n"
+                                     "}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
 TEST(UrlEncodedPostTests, FormPostManyTest) {
     auto url = Url{base + "/form_post.html"};
     auto response = cpr::Post(url, Multipart{{"x", 5}, {"y", 13}});


### PR DESCRIPTION
This is a fix for #128 which calls `curl_formfree()` on the value created by `curl_formadd()` to prevent memory from leaking after a multipart POST upload.

Only commit d39993c is needed, the other commits are because I based this request on top of PR #129.  If PR #129 is merged, then this will also merge cleanly on top of that with only a single commit.