### PR TITLE
Improve parsing of header fields

### DIFF
--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -1,5 +1,6 @@
 #include "cpr/util.h"
 
+#include <algorithm>
 #include <cctype>
 #include <cstdint>
 #include <iomanip>
@@ -29,10 +30,9 @@ Header parseHeader(const std::string& headers) {
         if (line.length() > 0) {
             auto found = line.find(":");
             if (found != std::string::npos) {
-                auto value = line.substr(found + 2, line.length() - 1);
-                if (value.back() == '\r') {
-                    value = value.substr(0, value.length() - 1);
-                }
+                auto value = line.substr(found + 1);
+                value.erase(0, value.find_first_not_of("\t "));
+                value.resize(std::min(value.size(), value.find_last_not_of("\t\n\r ") + 1));
                 header[line.substr(0, found)] = value;
             }
         }


### PR DESCRIPTION
Here in [`cpr/util.cpp#L30-L37`](https://github.com/whoshuu/cpr/blob/c6ae1ed77ef31702ca7050776ff4dcccf6138d28/cpr/util.cpp#L30-L37):
- For `Header:\r\n` or `Header: \n`, the program asserts an error because `value` is empty.
- For `Header:\n`, the program throws a `std::out_of_range` exception because of `found + 2`.

A real-life example would be GitHub [returning](https://github.com/search?utf8=%E2%9C%93&q=%22X-Geo-Block-List%22&type=Issues&ref=searchresults) `X-Geo-Block-List:\r\n`. There's also #127.

If the code I changed looks too cryptic, here's the expanded version:

``` cpp
auto found = line.find(":");
if (found != std::string::npos) {
    auto value = line.substr(found + 1);
    found = value.find_first_not_of("\t ");
    if (found != std::string::npos) {
        value.erase(0, found);
    }
    found = value.find_last_not_of("\t\n\r ");
    if (found != std::string::npos) {
        value.resize(found + 1);
    }
    header[line.substr(0, found)] = value;
}
```

Note that `\n` is not actually a part of `line` due to `std::getline`, but I included it in `"\t\n\r "` anyway in case the splitting method is changed in the future.

This also makes cpr more compliant with the [specification](https://tools.ietf.org/html/rfc7230#section-3.2). From what I understand:
- `\t` is allowed as optional whitespace:
  `OWS            = *( SP / HTAB )`
- Leading/trailing OWS is insignificant and should not be a part of the field value:
  `header-field   = field-name ":" OWS field-value OWS`
