### PR TITLE
Updated submodule URL to https instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For just getting this library up and running, I highly recommend forking the [ex
 If you already have a project you need to integrate C++ Requests with, the primary way is to use git submodules. Add this repository as a submodule of your root repository:
 
 ```shell
-git submodule add git@github.com:whoshuu/cpr.git
+git submodule add https://github.com/whoshuu/cpr.git
 git submodule update --init --recursive
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ For just getting this library up and running, I highly recommend forking the [ex
 If you already have a project you need to integrate C++ Requests with, the primary way is to use git submodules. Add this repository as a submodule of your root repository:
 
 ```shell
+git submodule add git@github.com:whoshuu/cpr.git
+OR 
 git submodule add https://github.com/whoshuu/cpr.git
+
 git submodule update --init --recursive
 ```
 


### PR DESCRIPTION
git@github.com:whoshuu/cpr.git used SSH which gave authentication errors on **repository rights**.
However, https://github.com/whoshuu/cpr.git worked. Please check the issue from some account other than your own.
