### PR TITLE
Update git submodules path in .gitsubmodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "opt/curl"]
 	path = opt/curl
-	url = git://github.com/whoshuu/curl.git
+	url = https://github.com/whoshuu/curl.git
 [submodule "opt/googletest"]
 	path = opt/googletest
-	url = git://github.com/whoshuu/googletest.git
+	url = https://github.com/whoshuu/googletest.git
 [submodule "opt/mongoose"]
 	path = opt/mongoose
-	url = git://github.com/whoshuu/mongoose.git
+	url = https://github.com/whoshuu/mongoose.git


### PR DESCRIPTION
Change submodules path to make Github pages build correctly as explained by Github documentation.
Check here for more info (https://help.github.com/articles/page-build-failed-invalid-submodule/).