### PR TITLE
Fix compilation warning. Silence some -Wextra warnings. Fix travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ matrix:
 
     # Xcode 7
     - os: osx
-      env: COMPILER=clang++ CCOMPILER=clang BREW_CMAKE=ON
+      env: COMPILER=clang++ CCOMPILER=clang
       osx_image: xcode7
   allow_failures:
     - env: COMPILER=g++-4.6 CCOMPILER=gcc-4.6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,11 @@ else()
     endif()
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic") # add warning flags
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic") # if compiler is GCC or Clang add warning flags
+endif()
+
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,6 @@ else()
     endif()
 endif()
 
-
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic") # if compiler is GCC or Clang add warning flags
-endif()
-
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ else()
     endif()
 endif()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic") # add warning flags
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
 

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -33,7 +33,7 @@ struct Buffer {
     template <typename Iterator>
     typename std::enable_if<std::is_same<typename std::iterator_traits<Iterator>::iterator_category,
                                          std::random_access_iterator_tag>::value>::type
-    is_random_access_iterator(Iterator begin, Iterator end) {}
+    is_random_access_iterator(Iterator /* begin */, Iterator /* end */ ) {}
 
     data_t data;
     unsigned long datalen;

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -164,12 +164,11 @@ static int basicAuth(struct mg_connection* conn) {
     auto response = std::string{"Hello world!"};
     const char* requested_auth;
     auto auth = std::string{"Basic"};
-    std::string auth_string;
     if ((requested_auth = mg_get_header(conn, "Authorization")) == NULL ||
         mg_strncasecmp(requested_auth, auth.data(), auth.length()) != 0) {
         return MG_FALSE;
     }
-    auth_string = {requested_auth};
+    auto auth_string = std::string{requested_auth};
     auto basic_token = auth_string.find(' ') + 1;
     auth_string = auth_string.substr(basic_token, auth_string.length() - basic_token);
     auth_string = base64_decode(auth_string);
@@ -369,7 +368,7 @@ static int deleteRequest(struct mg_connection* conn) {
     auto has_json_header = false;
     for (int i = 0; i < num_headers; ++i) {
         auto name = headers[i].name;
-        if (std::string{"Content-Type"} == headers[i].name &&
+        if (std::string{"Content-Type"} == name &&
                 std::string{"application/json"} == headers[i].value) {
             has_json_header = true;
         }

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -367,8 +367,7 @@ static int deleteRequest(struct mg_connection* conn) {
     auto headers = conn->http_headers;
     auto has_json_header = false;
     for (int i = 0; i < num_headers; ++i) {
-        auto name = headers[i].name;
-        if (std::string{"Content-Type"} == name &&
+        if (std::string{"Content-Type"} == headers[i].name &&
                 std::string{"application/json"} == headers[i].value) {
             has_json_header = true;
         }


### PR DESCRIPTION
I just hided an unused parameter warning : `is_random_access_iterator(Iterator /* begin */, Iterator /* end */ ) `

I have added some compile flags that are used in the projects I work on and hide them in CPR so that they do not show anymore.  