### PR TITLE
Add support for extending a multipart object

### DIFF
--- a/cpr/multipart.cpp
+++ b/cpr/multipart.cpp
@@ -4,4 +4,8 @@ namespace cpr {
 
 Multipart::Multipart(const std::initializer_list<Part>& parts) : parts{parts} {}
 
+void Multipart::AddPart(const Part& part) {
+    parts.push_back(part);
+}
+
 } // namespace cpr

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -65,7 +65,15 @@ struct Part {
 
 class Multipart {
   public:
+    template <class It>
+    Multipart(const It begin, const It end) {
+        for (It part = begin; part != end; ++part) {
+            AddPart(*part);
+        }
+    }
     Multipart(const std::initializer_list<Part>& parts);
+
+    void AddPart(const Part& part);
 
     std::vector<Part> parts;
 };

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -128,6 +128,41 @@ TEST(UrlEncodedPostTests, FormPostSingleTest) {
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
 
+TEST(UrlEncodedPostTests, FormPostAddMultipartPart) {
+    auto url = Url{base + "/form_post.html"};
+    auto multipart = Multipart{{"x", "5"}};
+    multipart.AddPart({"y", "13"});
+    auto response = cpr::Post(url, multipart);
+    auto expected_text = std::string{"{\n"
+                                     "  \"x\": 5,\n"
+                                     "  \"y\": 13,\n"
+                                     "  \"sum\": 18\n"
+                                     "}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
+TEST(UrlEncodedPostTests, FormPostMultipartIteratorTest) {
+    auto url = Url{base + "/form_post.html"};
+    std::vector<Part> parts;
+    parts.push_back({"x", "5"});
+    parts.push_back({"y", "13"});
+    auto response = cpr::Post(url, Multipart(parts.begin(), parts.end()));
+    auto expected_text = std::string{"{\n"
+                                     "  \"x\": 5,\n"
+                                     "  \"y\": 13,\n"
+                                     "  \"sum\": 18\n"
+                                     "}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
 TEST(UrlEncodedPostTests, FormPostFileTest) {
     auto filename = std::string{"test_file"};
     auto content = std::string{"hello world"};


### PR DESCRIPTION
Currently the only way to build a Multipart object is to use a constructor that receives a initializer_list.
This makes doing a multipart POST request practically impossible when we want to decide at runtime whether to include some paremeter in the request or not.

This patch fixes it by adding to the Multipart class:
-a iterator constructor
-a method that allows to add a Part struct
 
It mirrors the interface of the Payload class.