### PR TITLE
Fix Set{Body,Payload,Mulitpart} implementation

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -49,6 +49,7 @@ class Session::Impl {
     Url url_;
     Parameters parameters_;
     Proxies proxies_;
+    std::string body_;
 
     Response makeRequest(CURL* curl);
     static void freeHolder(CurlHolder* holder);
@@ -151,8 +152,9 @@ void Session::Impl::SetDigest(const Digest& auth) {
 void Session::Impl::SetPayload(Payload&& payload) {
     auto curl = curl_->handle;
     if (curl) {
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, payload.content.length());
-        curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, payload.content.data());
+        body_ = std::move(payload.content);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, body_.length());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body_.data());
     }
 }
 
@@ -263,8 +265,9 @@ void Session::Impl::SetCookies(const Cookies& cookies) {
 void Session::Impl::SetBody(Body&& body) {
     auto curl = curl_->handle;
     if (curl) {
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, body.length());
-        curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, body.data());
+        body_ = std::move(body);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, body_.length());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body_.data());
     }
 }
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -160,7 +160,7 @@ void Session::Impl::SetPayload(const Payload& payload) {
     auto curl = curl_->handle;
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, payload.content.length());
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.content.data());
+        curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, payload.content.data());
     }
 }
 
@@ -213,16 +213,17 @@ void Session::Impl::SetMultipart(const Multipart& multipart) {
 
         for (auto& part : multipart.parts) {
             std::vector<struct curl_forms> formdata;
-            formdata.push_back({CURLFORM_PTRNAME, part.name.data()});
+            formdata.push_back({CURLFORM_COPYNAME, part.name.data()});
             if (part.is_buffer) {
                 formdata.push_back({CURLFORM_BUFFER, part.value.data()});
-                formdata.push_back({CURLFORM_BUFFERPTR, reinterpret_cast<const char*>(part.data)});
                 formdata.push_back(
-                        {CURLFORM_BUFFERLENGTH, reinterpret_cast<const char*>(part.datalen)});
+                        {CURLFORM_COPYCONTENTS, reinterpret_cast<const char*>(part.data)});
+                formdata.push_back(
+                        {CURLFORM_CONTENTSLENGTH, reinterpret_cast<const char*>(part.datalen)});
             } else if (part.is_file) {
                 formdata.push_back({CURLFORM_FILE, part.value.data()});
             } else {
-                formdata.push_back({CURLFORM_PTRCONTENTS, part.value.data()});
+                formdata.push_back({CURLFORM_COPYCONTENTS, part.value.data()});
             }
             if (!part.content_type.empty()) {
                 formdata.push_back({CURLFORM_CONTENTTYPE, part.content_type.data()});
@@ -271,7 +272,7 @@ void Session::Impl::SetBody(const Body& body) {
     auto curl = curl_->handle;
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, body.length());
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.data());
+        curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, body.data());
     }
 }
 

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -65,7 +65,10 @@ struct Part {
 
 class Multipart {
   public:
+    Multipart() = default;
+    Multipart(Multipart&&) = default;
     Multipart(const std::initializer_list<Part>& parts);
+    Multipart& operator=(Multipart&&) = default;
 
     std::vector<Part> parts;
 };


### PR DESCRIPTION
I'm gonna be talking about problems with the pair of SetBody functions but the same thing applies to SetPayload and SetMultipart.
The following code demonstrates a bug in SetBody(const Body&):
```
    cpr::Session session;
    session.SetUrl(cpr::Url{"http://httpbin.org/post"});
    
    auto body = cpr::Body{"a"};
    session.SetBody(body);
    body = cpr::Body{"b"};
    
    auto r = session.Post(); // sends request with body equal to "b"
    std::cout << r.text << std::endl;
    
        
    if(true) {
        auto new_body = cpr::Body{"c"};
        session.SetBody(new_body);
    }
    
    r = session.Post(); // during this call libcurl uses pointer to freed memory
```
The current implementation doesn't instruct libcurl to copy data. As the above code suggests, we have to copy data in this SetBody function. 
However we can omit copying in the SetBody(Body&&) function but the current implementation of this function copies data. We can't do it by simply swapping implementations of SetBody(const Body&) and SetBody(Body&&). We have to take ownership of data that a Body object represents to be sure we don't have a pointer to freed memory when a request is actually done. We do this by adding a std::string variable to the Session::Impl class and using the move assignment operator of std::string. SetPayload(Payload&&) also uses this new string variable. For SetMultipart(Multipart&&) we add a Multipart object to the Session::Impl.