### PR TITLE
Use target_include_directories() in CMake

### DIFF
--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -1,7 +1,4 @@
 message(STATUS "Using CURL_INCLUDE_DIRS: ${CURL_INCLUDE_DIRS}.")
-include_directories(
-    ${CPR_INCLUDE_DIRS}
-    ${CURL_INCLUDE_DIRS})
 
 add_library(${CPR_LIBRARIES}
 
@@ -45,3 +42,14 @@ add_library(${CPR_LIBRARIES}
 message(STATUS "Using CURL_LIBRARIES: ${CURL_LIBRARIES}.")
 target_link_libraries(${CPR_LIBRARIES}
     ${CURL_LIBRARIES})
+
+if(NOT (CMAKE_VERSION VERSION_LESS 3.0))
+    target_include_directories(${CPR_LIBRARIES}
+        PUBLIC
+        ${CPR_INCLUDE_DIRS}
+        ${CURL_INCLUDE_DIRS})
+else()
+    include_directories(
+        ${CPR_INCLUDE_DIRS}
+        ${CURL_INCLUDE_DIRS})
+endif()


### PR DESCRIPTION
When using `cpr` in a CMake project, simply doing `add_subdirectory(path/to/cpr)` doesn't add curl and cpr include directories to target's public include path, as one might expect, so it has to be done manually.

This should fix that by attaching these include directories to the target as public.