### PR TITLE
Fix padding of 'Error' and 'Response' classes.

### DIFF
--- a/include/cpr/error.h
+++ b/include/cpr/error.h
@@ -41,8 +41,8 @@ class Error {
         return code != ErrorCode::OK;
     }
 
-    ErrorCode code;
     std::string message;
+    ErrorCode code;
 
   private:
     static ErrorCode getErrorCodeForCurlError(std::int32_t curl_code);

--- a/include/cpr/response.h
+++ b/include/cpr/response.h
@@ -24,13 +24,13 @@ class Response {
               url{CPR_FWD(p_url)}, elapsed{p_elapsed}, cookies{CPR_FWD(p_cookies)},
               error{CPR_FWD(p_error)} {}
 
-    std::int32_t status_code;
     std::string text;
     Header header;
     Url url;
     double elapsed;
     Cookies cookies;
     Error error;
+    std::int32_t status_code;
 };
 
 } // namespace cpr


### PR DESCRIPTION
Gets triggered by '-Wpadded'.
Tested with clang 5.