### PR TITLE
Add HTTP/2 support

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -294,20 +294,22 @@ void Session::Impl::SetVerifySsl(const VerifySsl& verify) {
 }
 
 void Session::Impl::SetProtocolVersion(const ProtocolVersion& protocolversion) {
+#if LIBCURL_VERSION_MAJOR >= 7
+#if LIBCURL_VERSION_MINOR >= 33
+#if LIBCURL_VERSION_PATCH >= 0
     auto curl = curl_->handle;
     if (curl) {
-        if ( protocolversion == cpr::HTTP::v2 )
-        {
-            if ( curl_version_info(CURLVERSION_NOW)->features & CURL_VERSION_HTTP2 )
-            {
+        if (protocolversion == cpr::HTTP::v2) {
+            if (curl_version_info(CURLVERSION_NOW)->features & CURL_VERSION_HTTP2) {
                 curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
-            }
-            else
-            {
+            } else {
                 throw std::runtime_error("no HTTP/2 support");
             }
         }
     }
+#endif
+#endif
+#endif
 }
 
 Response Session::Impl::Delete() {

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -35,6 +35,8 @@ class Session::Impl {
     void SetBody(const Body& body);
     void SetLowSpeed(const LowSpeed& low_speed);
     void SetVerifySsl(const VerifySsl& verify);
+    void SetProtocolVersion(const ProtocolVersion& protocolversion);
+
 
     Response Delete();
     Response Get();
@@ -291,6 +293,23 @@ void Session::Impl::SetVerifySsl(const VerifySsl& verify) {
     }
 }
 
+void Session::Impl::SetProtocolVersion(const ProtocolVersion& protocolversion) {
+    auto curl = curl_->handle;
+    if (curl) {
+        if ( protocolversion == cpr::HTTP::v2 )
+        {
+            if ( curl_version_info(CURLVERSION_NOW)->features & CURL_VERSION_HTTP2 )
+            {
+                curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+            }
+            else
+            {
+                throw std::runtime_error("no HTTP/2 support");
+            }
+        }
+    }
+}
+
 Response Session::Impl::Delete() {
     auto curl = curl_->handle;
     if (curl) {
@@ -445,6 +464,7 @@ void Session::SetBody(const Body& body) { pimpl_->SetBody(body); }
 void Session::SetBody(Body&& body) { pimpl_->SetBody(std::move(body)); }
 void Session::SetLowSpeed(const LowSpeed& low_speed) { pimpl_->SetLowSpeed(low_speed); }
 void Session::SetVerifySsl(const VerifySsl& verify) { pimpl_->SetVerifySsl(verify); }
+void Session::SetProtocolVersion(const ProtocolVersion& protocolversion) { pimpl_->SetProtocolVersion(protocolversion); }
 void Session::SetOption(const Url& url) { pimpl_->SetUrl(url); }
 void Session::SetOption(const Parameters& parameters) { pimpl_->SetParameters(parameters); }
 void Session::SetOption(Parameters&& parameters) { pimpl_->SetParameters(std::move(parameters)); }
@@ -465,6 +485,8 @@ void Session::SetOption(const Body& body) { pimpl_->SetBody(body); }
 void Session::SetOption(Body&& body) { pimpl_->SetBody(std::move(body)); }
 void Session::SetOption(const LowSpeed& low_speed) { pimpl_->SetLowSpeed(low_speed); }
 void Session::SetOption(const VerifySsl& verify) { pimpl_->SetVerifySsl(verify); }
+void Session::SetOption(const ProtocolVersion& protocolversion) { pimpl_->SetProtocolVersion(protocolversion); }
+
 Response Session::Delete() { return pimpl_->Delete(); }
 Response Session::Get() { return pimpl_->Get(); }
 Response Session::Head() { return pimpl_->Head(); }

--- a/include/cpr/cprtypes.h
+++ b/include/cpr/cprtypes.h
@@ -12,6 +12,7 @@ struct CaseInsensitiveCompare {
 
 using Header = std::map<std::string, std::string, CaseInsensitiveCompare>;
 using Url = std::string;
+using ProtocolVersion = enum HTTP { v1x, v2 };
 
 } // namespace cpr
 

--- a/include/cpr/cprtypes.h
+++ b/include/cpr/cprtypes.h
@@ -12,7 +12,7 @@ struct CaseInsensitiveCompare {
 
 using Header = std::map<std::string, std::string, CaseInsensitiveCompare>;
 using Url = std::string;
-using ProtocolVersion = enum HTTP { v1x, v2 };
+using ProtocolVersion = enum class HTTP { v1x, v2 };
 
 } // namespace cpr
 

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -46,6 +46,7 @@ class Session {
     void SetBody(const Body& body);
     void SetLowSpeed(const LowSpeed& low_speed);
     void SetVerifySsl(const VerifySsl& verify);
+    void SetProtocolVersion(const ProtocolVersion& protocolversion);
 
     // Used in templated functions
     void SetOption(const Url& url);
@@ -68,6 +69,7 @@ class Session {
     void SetOption(const Body& body);
     void SetOption(const LowSpeed& low_speed);
     void SetOption(const VerifySsl& verify);
+    void SetOption(const ProtocolVersion& protocolversion);
 
     Response Delete();
     Response Get();


### PR DESCRIPTION
This adds support for the HTTP/2 protocol to cpr. To use it set the option `cpr::ProtocolVersion{cpr::HTTP::v2}`. If the underlying CURL doesnt support HTTP/2 it throws a runtime error informing you about this issue.

It would be cool if this could be added as a CMake option which also checks if the underlying CURL supports HTTP/2, but I don't know enough about CMake to make this happen. Maybe someone else could add this here too.

This will resolve #116