### PR TITLE
fix CMake policy CMP0048 for project using CMake 3+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 2.8.7)
 
+if (POLICY CMP0048)
+   # cmake warns if loaded from a min-3.0-required parent dir, so silence the warning:
+   cmake_policy(SET CMP0048 NEW)
+ endif()
+
 # Allow use of project folders for IDEs like Visual Studio, so we
 # could organize projects into relevant folders: "cpr", "tests" & "external (libraries)".
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 2.8.7)
 
-if (POLICY CMP0048)
-   # cmake warns if loaded from a min-3.0-required parent dir, so silence the warning:
-   cmake_policy(SET CMP0048 NEW)
- endif()
+if(POLICY CMP0048)
+    # cmake warns if loaded from a min-3.0-required parent dir, so silence the warning:
+    cmake_policy(SET CMP0048 NEW)
+endif()
 
 # Allow use of project folders for IDEs like Visual Studio, so we
 # could organize projects into relevant folders: "cpr", "tests" & "external (libraries)".


### PR DESCRIPTION
Hi,

I'm building a library using your library. Everything works smoothly.

However, I do have a warning when running CMake:
```
CMake Warning (dev) at external/cpr/CMakeLists.txt:8 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    PROJECT_VERSION
    PROJECT_VERSION_MAJOR
    PROJECT_VERSION_MINOR
    PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.
```

After doing some searches on google, this is due to the fact I'm using CMake 3.0+ while yuor library is supporting up to 2.8.
However, starting from CMake 3.0, a new policy has been introduce, [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html).
A warning is then raised because your library does not specify any version in the `project` directive of your CMake.

I provided a fix that does not change the behavior: it basically explicitly specifies the policy (which is enabled implicitly but with a warning when using CMake 3.0+). This results in silencing the warning.

Best