### PR TITLE
Fix Get Request with Body

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -305,9 +305,7 @@ Response Session::Impl::Delete() {
 Response Session::Impl::Get() {
     auto curl = curl_->handle;
     if (curl) {
-        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, NULL);
-        curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
-        curl_easy_setopt(curl, CURLOPT_POST, 0L);
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "GET");
         curl_easy_setopt(curl, CURLOPT_NOBODY, 0L);
     }
 

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -69,6 +69,18 @@ TEST(BasicTests, BadHostTest) {
     EXPECT_EQ(ErrorCode::HOST_RESOLUTION_FAILURE, response.error.code);
 }
 
+TEST(BasicTests, RequestBodyTest) {
+    auto url = Url{base + "/body_get.html"};
+    auto body = Body{"message=abc123"};
+    auto response = cpr::Get(url, body);
+    auto expected_text = std::string{"abc123"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"text/html"}, response.header["content-type"]);
+    EXPECT_EQ(200, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
 TEST(CookiesTests, SingleCookieTest) {
     auto url = Url{base + "/basic_cookies.html"};
     auto cookies = Cookies{{"hello", "world"}, {"my", "another; fake=cookie;"}};

--- a/test/server.cpp
+++ b/test/server.cpp
@@ -267,6 +267,16 @@ static int twoRedirects(struct mg_connection* conn) {
     return MG_TRUE;
 }
 
+static int bodyGet(struct mg_connection* conn) {
+    char message[100];
+    mg_get_var(conn, "Message", message, sizeof(message));
+    auto response = std::string{message};
+    mg_send_status(conn, 200);
+    mg_send_header(conn, "content-type", "text/html");
+    mg_send_data(conn, response.data(), response.length());
+    return MG_TRUE;
+}
+
 static int urlPost(struct mg_connection* conn) {
     mg_send_status(conn, 201);
     mg_send_header(conn, "content-type", "application/json");
@@ -549,6 +559,8 @@ static int evHandler(struct mg_connection* conn, enum mg_event ev) {
                 return twoRedirects(conn);
             } else if (Url{conn->uri} == "/url_post.html") {
                 return urlPost(conn);
+            } else if (Url{conn->uri} == "/body_get.html") {
+                return bodyGet(conn);
             } else if (Url{conn->uri} == "/json_post.html") {
                 return jsonPost(conn);
             } else if (Url{conn->uri} == "/form_post.html") {


### PR DESCRIPTION
Setting "Body" doesn't work for cpr::Get #166.

Fix sending a `GET` request with a body.