### PR TITLE
Revert static cast for MSVC.

### DIFF
--- a/cpr/timeout.cpp
+++ b/cpr/timeout.cpp
@@ -20,7 +20,7 @@ long Timeout::Milliseconds() const {
                                    std::to_string(ms.count()) + " ms.");
     }
 
-    return ms.count();
+    return static_cast<long>(ms.count());
 }
 
 } // namespace cpr


### PR DESCRIPTION
Revert one commit of #219. That cast is needed for MSVC compiler.