### PR TITLE
Add option to set Position-Independent Code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ cpr_option(CPR_CURL_NOSIGNAL "Set to ON to disable use of signals in libcurl." O
 cpr_option(USE_SYSTEM_GTEST
     "If ON, this project will look in the system paths for an installed gtest library" OFF)
 cpr_option(CMAKE_USE_OPENSSL "Use OpenSSL code. Experimental" ON)
+cpr_option(CPR_SET_PIC "Set Position-Independent Code flag" OFF)
 message(STATUS "=======================================================")
 
 if(BUILD_CPR_TESTS)

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -43,6 +43,12 @@ message(STATUS "Using CURL_LIBRARIES: ${CURL_LIBRARIES}.")
 target_link_libraries(${CPR_LIBRARIES}
     ${CURL_LIBRARIES})
 
+if(CPR_SET_PIC)
+    message(STATUS "Setting Position-Independent Code.")
+    set_target_properties(${CPR_LIBRARIES}
+        PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+
 if(NOT (CMAKE_VERSION VERSION_LESS 3.0))
     target_include_directories(${CPR_LIBRARIES}
         PUBLIC


### PR DESCRIPTION
It can be useful if you need to link `libcpr.a` to a dynamic library (as I needed to do).