### PR TITLE
make the response object return more info about headers

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -413,13 +413,20 @@ Response Session::Impl::makeRequest(CURL* curl) {
     }
     curl_slist_free_all(raw_cookies);
 
+    std::string status_line;
+    std::string reason;
+    Header header = cpr::util::parseHeader(header_string, &status_line, &reason);
+
     return Response{static_cast<std::int32_t>(response_code),
                     std::move(response_string),
-                    cpr::util::parseHeader(header_string),
+                    std::move(header),
                     std::move(raw_url),
                     elapsed,
                     std::move(cookies),
-                    Error(curl_error, curl_->error)};
+                    Error(curl_error, curl_->error),
+                    std::move(header_string),
+                    std::move(status_line),
+                    std::move(reason)};
 }
 
 // clang-format off

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -11,7 +11,7 @@
 namespace cpr {
 namespace util {
 
-Header parseHeader(const std::string& headers) {
+Header parseHeader(const std::string& headers, std::string* status_line, std::string* reason) {
     Header header;
     std::vector<std::string> lines;
     std::istringstream stream(headers);
@@ -24,6 +24,26 @@ Header parseHeader(const std::string& headers) {
 
     for (auto& line : lines) {
         if (line.substr(0, 5) == "HTTP/") {
+            // set the status_line if it was given
+            if ((status_line != nullptr) || (reason != nullptr)) {
+                line.resize(std::min(line.size(), line.find_last_not_of("\t\n\r ") + 1));
+                if (status_line != nullptr) {
+                    *status_line = line;
+                }
+
+                // set the reason if it was given
+                if (reason != nullptr) {
+                    auto pos1 = line.find_first_of("\t ");
+                    size_t pos2 = std::string::npos;
+                    if (pos1 != std::string::npos) {
+                        pos2 = line.find_first_of("\t ", pos1 + 1);
+                    }
+                    if (pos2 != std::string::npos) {
+                        line.erase(0, pos2 + 1);
+                        *reason = line;
+                    }
+                }
+            }
             header.clear();
         }
 

--- a/include/cpr/response.h
+++ b/include/cpr/response.h
@@ -17,12 +17,14 @@ class Response {
 
     template <typename TextType, typename HeaderType, typename UrlType, typename CookiesType,
               typename ErrorType>
-    Response(const std::int32_t& p_status_code, TextType&& p_text, HeaderType&& p_header, UrlType&& p_url,
-             const double& p_elapsed, CookiesType&& p_cookies = Cookies{},
-             ErrorType&& p_error = Error{})
+    Response(const std::int32_t& p_status_code, TextType&& p_text, HeaderType&& p_header,
+             UrlType&& p_url, const double& p_elapsed, CookiesType&& p_cookies = Cookies{},
+             ErrorType&& p_error = Error{}, TextType&& p_raw_header = "",
+             TextType&& p_status_line = "", TextType&& p_reason = "")
             : status_code{p_status_code}, text{CPR_FWD(p_text)}, header{CPR_FWD(p_header)},
               url{CPR_FWD(p_url)}, elapsed{p_elapsed}, cookies{CPR_FWD(p_cookies)},
-              error{CPR_FWD(p_error)} {}
+              error{CPR_FWD(p_error)}, raw_header{CPR_FWD(p_raw_header)}, reason{CPR_FWD(p_reason)},
+              status_line{CPR_FWD(p_status_line)} {}
 
     std::int32_t status_code;
     std::string text;
@@ -31,6 +33,9 @@ class Response {
     double elapsed;
     Cookies cookies;
     Error error;
+    std::string raw_header;
+    std::string status_line;
+    std::string reason;
 };
 
 } // namespace cpr

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -9,7 +9,8 @@
 namespace cpr {
 namespace util {
 
-Header parseHeader(const std::string& headers);
+Header parseHeader(const std::string& headers, std::string* status_line = nullptr,
+                   std::string* reason = nullptr);
 size_t writeFunction(void* ptr, size_t size, size_t nmemb, std::string* data);
 std::vector<std::string> split(const std::string& to_split, char delimiter);
 std::string urlEncode(const std::string& response);


### PR DESCRIPTION
I've added code to make a few Header related info  to be available through the Response object

What's now available:
- Response.raw_header - contains the status_line and all headers that were received as a string
- Response.status_line - example: "HTTP/1.1 407 Proxy Authentication Required"
- Response.reason - example: "Proxy Authentication Required"