### PR TITLE
Removes BUILD_CPR_TESTS from cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,3 +79,5 @@ add_subdirectory(cpr)
 if(BUILD_CPR_TESTS)
     add_subdirectory(test)
 endif()
+
+unset(BUILD_CPR_TESTS CACHE)


### PR DESCRIPTION
The project's CMakeLists.txt file has the `BUILD_CPR_TESTS` to ON by default, but when added as submodule most probably this is not be desirable (it is my case).

The problem is that most of the times (especially on the first checkout) one forgets about this and simply executes the cmake command, which produces a cache of values and on that cache the value of `BUILD_CPR_TESTS` is set to ON. After you realize about the tests being built and change it on the CMakeLists.txt file, there is no effect on test build since cmake will use the cached value as long as it is there (workarounds are always to edit/delete the cache and re-run cmake).

Unsetting the value of `BUILD_CPR_TESTS` right before the end of the file will force cmake on the next execution to read again the value on the CMakeLists.txt file instead of using the cached one, which will have no effect on building time but it will on personal time spent until one realizes about the cmake cache smashing the clearly written value on the file (again, this has happened to me in several occasions).

This can also be done with any other parameters that are to be changed constantly or by the project using cpr as submodule mantainer (and default test building is most surely one of them).