### PR TITLE
Use CURLOPT_POST and CURLUOPT_HTTPGET instead of CURLOPT_CUSTOMREQUEST

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -314,7 +314,7 @@ Response Session::Impl::Get() {
     auto curl = curl_->handle;
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_NOBODY, 0L);
-        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "GET");
+        curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
     }
 
     return makeRequest(curl);
@@ -354,7 +354,7 @@ Response Session::Impl::Post() {
     auto curl = curl_->handle;
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_NOBODY, 0L);
-        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "POST");
+        curl_easy_setopt(curl, CURLOPT_POST, 1L);
     }
 
     return makeRequest(curl);


### PR DESCRIPTION
CURLOPT_POST and CURLOPT_HTTPGET change the behaviour of curl, e.g. an HTTP-Return with 302 would use a subsequent GET to follow the new location. When CURLOPT_CUSTOMREQUEST is used, then all redirections are also done with this method, which can break expected behaviour.