### PR TITLE
Remove clearing of system proxy

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -381,6 +381,8 @@ Response Session::Impl::makeRequest(CURL* curl) {
     auto protocol = url_.substr(0, url_.find(':'));
     if (proxies_.has(protocol)) {
         curl_easy_setopt(curl, CURLOPT_PROXY, proxies_[protocol].data());
+    } else {
+        curl_easy_setopt(curl, CURLOPT_PROXY, nullptr);
     }
 
     curl_->error[0] = '\0';

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -381,8 +381,6 @@ Response Session::Impl::makeRequest(CURL* curl) {
     auto protocol = url_.substr(0, url_.find(':'));
     if (proxies_.has(protocol)) {
         curl_easy_setopt(curl, CURLOPT_PROXY, proxies_[protocol].data());
-    } else {
-        curl_easy_setopt(curl, CURLOPT_PROXY, "");
     }
 
     curl_->error[0] = '\0';


### PR DESCRIPTION
Setting CURLTOPS_PROXY to "" will ignore the system level proxy settings. This is not curls default behavior