### PR TITLE
Add background-color to website

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -4,6 +4,7 @@ body {
   padding:50px;
   font:18px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
   color:#777;
+  background-color: #fff;
   font-weight:300;
 }
 


### PR DESCRIPTION
The background-color on the website is missing. Without it, the browser falls back on the default color, which is [user-configurable](https://support.mozilla.org/en-US/kb/change-fonts-and-colors-websites-use#w_change-font-color).

### Before:

![screenshot_2019-12-17T19-50-25](https://user-images.githubusercontent.com/3681516/71025246-ec86d080-2106-11ea-9c28-7ade7b64502f.png)

### After:

![screenshot_2019-12-17T19-51-57](https://user-images.githubusercontent.com/3681516/71025257-f27cb180-2106-11ea-9e0b-eed62728ca2d.png)
