### PR TITLE
Add version information for shared libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,19 @@ endif()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")
 
-project(cpr CXX)
+# Read version from text file.
+file(STRINGS "VERSION" cpr_temporary_version_string)
+if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0)
+    project(cpr VERSION "${cpr_temporary_version_string}" LANGUAGES CXX)
+else()
+    # CMake < 3.0 had no way to specify the project version.
+    project(cpr CXX)
+    set(${PROJECT_NAME}_VERSION "${cpr_temporary_version_string}")
+    # Convert version string into list, ...
+    string(REPLACE "." ";" cpr_temporary_list ${${PROJECT_NAME}_VERSION})
+    # ... and set major version to first element.
+    list(GET cpr_temporary_list 0 ${PROJECT_NAME}_VERSION_MAJOR)
+endif()
 
 if(NOT ${CMAKE_VERSION} VERSION_LESS 3.2)
     set(CMAKE_CXX_STANDARD 11)

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -55,6 +55,12 @@ else()
         ${CURL_INCLUDE_DIRS})
 endif()
 
+# Set version for shared libraries.
+set_target_properties(${CPR_LIBRARIES}
+     PROPERTIES
+     VERSION ${${PROJECT_NAME}_VERSION}
+     SOVERSION ${${PROJECT_NAME}_VERSION_MAJOR})
+
 install(TARGETS ${CPR_LIBRARIES}
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib


### PR DESCRIPTION
Read version information from the file [VERSION](https://github.com/whoshuu/cpr/blob/master/VERSION) and add the variables
cpr_VERSION and cpr_VERSION_MAJOR. cpr_VERSION_MAJOR is used as SOVERSION.

My SOVERSION choice implies that the ABI does only break when the major version number changes. If that is not the case it should be changed.

`file(STRINGS …)` is available in 2.8.7: <https://cmake.org/cmake/help/v2.8.7/cmake.html#command:file>  
`project(… VERSION …)` is available in 3.0: <https://cmake.org/cmake/help/v3.0/command/project.html>  
`string(REPLACE …)` is available in 2.8.7: <https://cmake.org/cmake/help/v2.8.7/cmake.html#command:string>  
`list(GET …)` is available in 2.8.7: <https://cmake.org/cmake/help/v2.8.7/cmake.html#command:list>  
`set_target_properties(… VERSION … SOVERSION …)` is available in 2.8.7: <https://cmake.org/cmake/help/v2.8.7/cmake.html#command:set_target_properties>