### PR TITLE
Update curl to 7.67 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
-[submodule "opt/curl"]
-	path = opt/curl
-	url = https://github.com/whoshuu/curl.git
 [submodule "opt/googletest"]
 	path = opt/googletest
 	url = https://github.com/whoshuu/googletest.git
 [submodule "opt/mongoose"]
 	path = opt/mongoose
 	url = https://github.com/whoshuu/mongoose.git
+[submodule "opt/curl"]
+	path = opt/curl
+	url = https://github.com/curl/curl.git


### PR DESCRIPTION
This addresses #342 -- uploading buffers larger than about 16,000 bytes results in corrupt data.

There's no changes to cpr just simply a curl version bump.

I've not rigorously tested this change yet.