### PR TITLE
use -D BUILD_SHARED_LIBS to create .so file instead of .a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ cpr_option(CPR_CURL_NOSIGNAL "Set to ON to disable use of signals in libcurl." O
 cpr_option(USE_SYSTEM_GTEST
     "If ON, this project will look in the system paths for an installed gtest library" OFF)
 cpr_option(CMAKE_USE_OPENSSL "Use OpenSSL code. Experimental" ON)
+cpr_option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 message(STATUS "=======================================================")
 
 if(BUILD_CPR_TESTS)

--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -1,6 +1,10 @@
 message(STATUS "Using CURL_INCLUDE_DIRS: ${CURL_INCLUDE_DIRS}.")
 
-add_library(${CPR_LIBRARIES}
+if($(BUILD_SHARED_LIBS))
+    set(SHARED SHARED)
+endif()
+
+add_library(${CPR_LIBRARIES} ${SHARED}
 
     # Source files
     auth.cpp


### PR DESCRIPTION
I thought this switch may be useful. It certainly is for me.