### PR TITLE
Have libcurl request all compression encodings it can handle.

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -85,6 +85,7 @@ Session::Impl::Impl() {
 #ifdef CPR_CURL_NOSIGNAL
         curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
 #endif
+
 #if LIBCURL_VERSION_MAJOR >= 7
 #if LIBCURL_VERSION_MINOR >= 25
 #if LIBCURL_VERSION_PATCH >= 0
@@ -486,6 +487,13 @@ Response Session::Impl::makeRequest(CURL* curl) {
     } else {
         curl_easy_setopt(curl, CURLOPT_PROXY, nullptr);
     }
+
+#if LIBCURL_VERSION_MAJOR >= 7
+#if LIBCURL_VERSION_MINOR >= 21
+	/* enable all supported built-in compressions */
+	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+#endif
+#endif
 
     curl_->error[0] = '\0';
 


### PR DESCRIPTION
Following the instructions [here](https://curl.haxx.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html), this makes libcurl use all the flavors of compression it was built with, usually including zlib at the least.