### PR TITLE
Added an option to disable cookie encoding #369

### DIFF
--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -3,20 +3,19 @@
 #include "cpr/util.h"
 
 namespace cpr {
-
-Cookies::Cookies(const std::initializer_list<std::pair<const std::string, std::string>>& pairs)
-        : map_{pairs} {}
-
 std::string Cookies::GetEncoded() const {
     std::stringstream stream;
     for (const auto& item : map_) {
-        stream << cpr::util::urlEncode(item.first) << "=";
+        // Depending on if encoding is set to "true", we will URL-encode cookies
+        stream << (encode ? cpr::util::urlEncode(item.first) : item.first) << "=";
+
         // special case version 1 cookies, which can be distinguished by
         // beginning and trailing quotes
         if (!item.second.empty() && item.second.front() == '"' && item.second.back() == '"') {
             stream << item.second;
         } else {
-            stream << cpr::util::urlEncode(item.second);
+            // Depending on if encoding is set to "true", we will URL-encode cookies
+            stream << (encode ? cpr::util::urlEncode(item.second) : item.second);
         }
         stream << "; ";
     }

--- a/include/cpr/cookies.h
+++ b/include/cpr/cookies.h
@@ -10,9 +10,22 @@ namespace cpr {
 
 class Cookies {
   public:
-    Cookies() {}
-    Cookies(const std::initializer_list<std::pair<const std::string, std::string>>& pairs);
-    Cookies(const std::map<std::string, std::string>& map) : map_{map} {}
+    /**
+     * Should we URL-encode cookies when making a request.
+     * Based on RFC6265, it is recommended but not mandatory to encode cookies.
+     * 
+     * -------
+     * To maximize compatibility with user agents, servers that wish to
+     * store arbitrary data in a cookie-value SHOULD encode that data, for
+     * example, using Base64 [RFC4648].
+     * -------
+     * Source: RFC6265 (https://www.ietf.org/rfc/rfc6265.txt)
+     **/
+    bool encode{true};
+
+    Cookies(bool encode = true) : encode(encode) {}
+    Cookies(const std::initializer_list<std::pair<const std::string, std::string>>& pairs, bool encode = true) : encode(encode), map_{pairs} {}
+    Cookies(const std::map<std::string, std::string>& map, bool encode = true) : encode(encode), map_{map} {}
 
     std::string& operator[](const std::string& key);
     std::string GetEncoded() const;


### PR DESCRIPTION
Allows to specify in the `Cookie` constructor if cookies should be URL encoded or not.