### PR TITLE
Add move constructor and assignment to Session

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -549,6 +549,8 @@ Response Session::Impl::makeRequest(CURL* curl) {
 
 // clang-format off
 Session::Session() : pimpl_{ new Impl{} } {}
+Session::Session(Session&& other) : pimpl_{ std::move(other.pimpl_) } {}
+Session& Session::operator=(Session&& other) { pimpl_ = std::move(other.pimpl_); return *this; }
 Session::~Session() {}
 void Session::SetUrl(const Url& url) { pimpl_->SetUrl(url); }
 void Session::SetParameters(const Parameters& parameters) { pimpl_->SetParameters(parameters); }

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -33,6 +33,9 @@ class Session {
     Session();
     ~Session();
 
+    Session(Session&& other);
+    Session& operator=(Session&& other);
+
     void SetUrl(const Url& url);
     void SetParameters(const Parameters& parameters);
     void SetParameters(Parameters&& parameters);


### PR DESCRIPTION
Add move constructor and assignment to Session to enable returning Session object from functions like this:

```cpp
cpr::Session session_factory()
{
  cpr::Session session{};
  session.SetUrl(url_);
  if (auth_.has_value())
  {
    session.SetAuth(*auth_);
  }
  return session;
}
```