### PR TITLE
Fix tests build when CMAKE_USE_OPENSSL=OFF

### DIFF
--- a/test/httpsServer.cpp
+++ b/test/httpsServer.cpp
@@ -20,8 +20,10 @@ mg_connection* HttpsServer::initServer(mg_mgr* mgr,
     mg_mgr_init(mgr, this);
 
     mg_bind_opts bind_opts{};
+#ifdef CMAKE_USE_OPENSSL
     bind_opts.ssl_cert = sslCertFileName.c_str();
     bind_opts.ssl_key = sslKeyFileName.c_str();
+#endif
     std::string port = std::to_string(GetPort());
     mg_connection* c = mg_bind_opt(mgr, port.c_str(), event_handler, bind_opts);
     mg_set_protocol_http_websocket(c);


### PR DESCRIPTION
* We are defining MG_ENABLE_SSL only when CMAKE_USE_OPENSSL
  is enabled thus [ssl_cert, ssl_key] fields would be missing
  otherwise.