### PR TITLE
Pass correct data type when setting CURLOPT_POSTFIELDSIZE_LARGE

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -181,7 +181,7 @@ void Session::Impl::SetPayload(Payload&& payload) {
     hasBodyOrPayload_ = true;
     auto curl = curl_->handle;
     if (curl) {
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, payload.content.length());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(payload.content.length()));
         curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, payload.content.c_str());
     }
 }
@@ -190,7 +190,7 @@ void Session::Impl::SetPayload(const Payload& payload) {
     hasBodyOrPayload_ = true;
     auto curl = curl_->handle;
     if (curl) {
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, payload.content.length());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(payload.content.length()));
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.content.c_str());
     }
 }


### PR DESCRIPTION
* Somehow when compiling with MSVC CURLOPT_POSTFIELDSIZE_LARGE ends up
  being set to some really large value, casting length to curl_off_t
  fixes that.
* Example nginx log message: `100 client intended to send too large body: 200127437130956800 bytes`.