### PR TITLE
Add ability to add proxy out of initialization

### DIFF
--- a/cpr/proxies.cpp
+++ b/cpr/proxies.cpp
@@ -10,6 +10,10 @@ namespace cpr {
 Proxies::Proxies(const std::initializer_list<std::pair<const std::string, std::string>>& hosts)
         : hosts_{hosts} {}
 
+void add(const std::string& protocol, std::string proxy_url) {
+    hosts_[protocol] = std::move(proxy_url);
+}
+
 bool Proxies::has(const std::string& protocol) const {
     return hosts_.count(protocol) > 0;
 }

--- a/include/cpr/proxies.h
+++ b/include/cpr/proxies.h
@@ -13,6 +13,7 @@ class Proxies {
     Proxies() {}
     Proxies(const std::initializer_list<std::pair<const std::string, std::string>>& hosts);
 
+    void add(const std::string& protocol, std::string proxy_url);
     bool has(const std::string& protocol) const;
     const std::string& operator[](const std::string& protocol);
 


### PR DESCRIPTION
In a project of mine, I want to construct the proxies option based on external input. This is currently not possible as `cpr::Proxies` has to be completely constructed in the initialization and there is no way to add new proxy for a certain protocol for the object.

With my slight change in the API, something like the following will be possible
``` c++
cpr::Proxies proxies{};
proxies["http"]="url_to_proxy"
```

I would love to be able to use that.