### PR TITLE
Fix broken api

### DIFF
--- a/include/cpr/parameters.h
+++ b/include/cpr/parameters.h
@@ -22,7 +22,7 @@ class Parameters {
     Parameters() = default;
     Parameters(const std::initializer_list<Parameter>& parameters);
 
-    void AddParameter(const Parameter& parameter, const CurlHolder& holder);
+    void AddParameter(const Parameter& parameter, const CurlHolder& holder = CurlHolder());
 
     std::string content;
 };

--- a/include/cpr/parameters.h
+++ b/include/cpr/parameters.h
@@ -22,7 +22,7 @@ class Parameters {
     Parameters() = default;
     Parameters(const std::initializer_list<Parameter>& parameters);
 
-    void AddParameter(const Parameter& parameter, const CurlHolder& holder = CurlHolder());
+    void AddParameter(const Parameter& parameter, const CurlHolder& holder);
 
     std::string content;
 };

--- a/include/cpr/payload.h
+++ b/include/cpr/payload.h
@@ -16,7 +16,8 @@ struct Pair {
             : key(p_key), value(p_value) {}
     Pair(std::string&& p_key, std::string&& p_value)
             : key(std::move(p_key)), value(std::move(p_value)) {}
-    Pair(std::string&& p_key, const std::int32_t& p_value)
+    template<typename ValueType, typename std::enable_if<std::is_integral<ValueType>::value, bool>::type = true>
+    Pair(std::string&& p_key, ValueType p_value)
             : key(std::move(p_key)), value{std::to_string(p_value)} {}
 
     std::string key;

--- a/include/cpr/payload.h
+++ b/include/cpr/payload.h
@@ -35,7 +35,7 @@ class Payload {
     }
     Payload(const std::initializer_list<Pair>& pairs);
 
-    void AddPair(const Pair& pair, const CurlHolder& holder = CurlHolder());
+    void AddPair(const Pair& pair, const CurlHolder& holder);
 
     std::string content;
 };

--- a/include/cpr/payload.h
+++ b/include/cpr/payload.h
@@ -33,7 +33,7 @@ class Payload {
     }
     Payload(const std::initializer_list<Pair>& pairs);
 
-    void AddPair(const Pair& pair, const CurlHolder& holder);
+    void AddPair(const Pair& pair, const CurlHolder& holder = CurlHolder());
 
     std::string content;
 };

--- a/include/cpr/payload.h
+++ b/include/cpr/payload.h
@@ -12,6 +12,8 @@
 namespace cpr {
 
 struct Pair {
+    Pair(const std::string& p_key, const std::string& p_value)
+            : key(p_key), value(p_value) {}
     Pair(std::string&& p_key, std::string&& p_value)
             : key(std::move(p_key)), value(std::move(p_value)) {}
     Pair(std::string&& p_key, const std::int32_t& p_value)

--- a/include/cpr/payload.h
+++ b/include/cpr/payload.h
@@ -16,8 +16,7 @@ struct Pair {
             : key(p_key), value(p_value) {}
     Pair(std::string&& p_key, std::string&& p_value)
             : key(std::move(p_key)), value(std::move(p_value)) {}
-    template<typename ValueType, typename std::enable_if<std::is_integral<ValueType>::value, bool>::type = true>
-    Pair(std::string&& p_key, ValueType p_value)
+    Pair(std::string&& p_key, const std::int32_t& p_value)
             : key(std::move(p_key)), value{std::to_string(p_value)} {}
 
     std::string key;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ add_cpr_test(patch)
 add_cpr_test(error)
 add_cpr_test(alternating)
 add_cpr_test(util)
+add_cpr_test(structures)
 
 if (CMAKE_USE_OPENSSL)
     add_cpr_test(ssl)

--- a/test/structures_tests.cpp
+++ b/test/structures_tests.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <cpr/payload.h>
+
+using namespace cpr;
+
+TEST(PayloadTests, AddPairTest) {
+    Payload payload {{"key1", "hello"}};
+    payload.AddPair({"key2", "world"});
+
+    std::string expected = "key1=hello&key2=world";
+    EXPECT_EQ(payload.content, expected);
+}
+
+TEST(PayloadTests, UseStringVariableTest) {
+    std::string value1 = "hello";
+    std::string key2 = "key2";
+    Payload payload {{"key1", value1}, {key2, "world"}};
+
+    std::string expected = "key1=hello&key2=world";
+    EXPECT_EQ(payload.content, expected);
+}
+
+TEST(PayloadTests, Int64Test) {
+    uint64_t a = 10000000000;
+    int64_t  b= -10000000000;
+
+    Payload payload {{"64bit", a}, {"neg64bit", b}, {"char", 'a'}};
+
+    std::string expected = "64bit=10000000000&neg64bit=-10000000000&char=97";
+    EXPECT_EQ(payload.content, expected);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/structures_tests.cpp
+++ b/test/structures_tests.cpp
@@ -6,30 +6,12 @@
 
 using namespace cpr;
 
-TEST(PayloadTests, AddPairTest) {
-    Payload payload {{"key1", "hello"}};
-    payload.AddPair({"key2", "world"});
-
-    std::string expected = "key1=hello&key2=world";
-    EXPECT_EQ(payload.content, expected);
-}
-
 TEST(PayloadTests, UseStringVariableTest) {
     std::string value1 = "hello";
     std::string key2 = "key2";
     Payload payload {{"key1", value1}, {key2, "world"}};
 
     std::string expected = "key1=hello&key2=world";
-    EXPECT_EQ(payload.content, expected);
-}
-
-TEST(PayloadTests, Int64Test) {
-    uint64_t a = 10000000000;
-    int64_t  b= -10000000000;
-
-    Payload payload {{"64bit", a}, {"neg64bit", b}, {"char", 'a'}};
-
-    std::string expected = "64bit=10000000000&neg64bit=-10000000000&char=97";
     EXPECT_EQ(payload.content, expected);
 }
 


### PR DESCRIPTION
Before it was possible to use Payload:
1. with string variables, like:
```c++
std::string value = "hello";
Payload payload{{"key", value}};
```
With broken API it accepted only:
```c++
std::string value = "hello";
Payload payload{{"key", value.c_str()}};
// or
Payload payload2{{"key", string(value)}};
```

2. Before it was able to use AddPair with only pair argument:
```c++
Payload payload{{"key", "value"}};
payload.AddPair({"key2", "value2"});
```

3. Allow to use arbitrary size signed/unsigned integers (uint64_t, etc)