### PR TITLE
Payload with string variables

### DIFF
--- a/include/cpr/payload.h
+++ b/include/cpr/payload.h
@@ -12,6 +12,8 @@
 namespace cpr {
 
 struct Pair {
+    Pair(const std::string& p_key, const std::string& p_value)
+            : key(p_key), value(p_value) {}
     Pair(std::string&& p_key, std::string&& p_value)
             : key(std::move(p_key)), value(std::move(p_value)) {}
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ add_cpr_test(patch)
 add_cpr_test(error)
 add_cpr_test(alternating)
 add_cpr_test(util)
+add_cpr_test(structures)
 
 if (CMAKE_USE_OPENSSL)
     add_cpr_test(ssl)

--- a/test/structures_tests.cpp
+++ b/test/structures_tests.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <cpr/payload.h>
+
+using namespace cpr;
+
+TEST(PayloadTests, UseStringVariableTest) {
+    std::string value1 = "hello";
+    std::string key2 = "key2";
+    Payload payload {{"key1", value1}, {key2, "world"}};
+
+    std::string expected = "key1=hello&key2=world";
+    EXPECT_EQ(payload.content, expected);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Return back the ability to create payload with string variables:
currently in master the following will not compile:
```c++
std::string key = "hello";
std::string val = "world";
Payload payload{{key, val}}; //  This gives compilation error
// Payload payload{{"hello", "world"}}; // this compiles ok in master
```
