### PR TITLE
Fix for Parameters using string variable

### DIFF
--- a/include/cpr/parameters.h
+++ b/include/cpr/parameters.h
@@ -10,6 +10,8 @@
 namespace cpr {
 
 struct Parameter {
+    Parameter(const std::string& key, const std::string& value)
+            : key{key}, value{value} {}
     Parameter(std::string&& key, std::string&& value)
             : key{std::move(key)}, value{std::move(value)} {}
 

--- a/test/structures_tests.cpp
+++ b/test/structures_tests.cpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include <cpr/payload.h>
+#include <cpr/parameters.h>
 
 using namespace cpr;
 
@@ -13,6 +14,15 @@ TEST(PayloadTests, UseStringVariableTest) {
 
     std::string expected = "key1=hello&key2=world";
     EXPECT_EQ(payload.content, expected);
+}
+
+TEST(ParametersTests, UseStringVariableTest) {
+    std::string value1 = "hello";
+    std::string key2 = "key2";
+    Parameters parameters {{"key1", value1}, {key2, "world"}};
+
+    std::string expected = "key1=hello&key2=world";
+    EXPECT_EQ(parameters.content, expected);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Similar to Payload fix this PR fixes to use Parameters with string variables:
```c++
std::string key = "hello";
std::string val = "world";
Parameters parameters{ {key, val} };
```