### PR TITLE
Provide hashes for git content to replace the security of submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if(NOT USE_SYSTEM_CURL OR NOT CURL_FOUND)
     set(FETCHCONTENT_QUIET OFF CACHE INTERNAL "" FORCE)
     FetchContent_Declare(curl
                          GIT_REPOSITORY         https://github.com/curl/curl.git
-                         GIT_TAG                curl-7_69_1
+                         GIT_TAG                b81e0b07784dc4c1e8d0a86194b9d28776d071c0 # the hash for curl-7_69_1
                          GIT_PROGRESS           TRUE
                          USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
 
@@ -102,7 +102,7 @@ if(BUILD_CPR_TESTS)
         endif()
         FetchContent_Declare(googletest
                              GIT_REPOSITORY         https://github.com/google/googletest.git
-                             GIT_TAG                release-1.10.0
+                             GIT_TAG                703bd9caab50b139428cea1aaff9974ebee5742e # the hash for release-1.10.0
                              GIT_PROGRESS           TRUE
                              USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
         FetchContent_MakeAvailable(googletest)
@@ -125,7 +125,7 @@ if(BUILD_CPR_TESTS)
     message(STATUS "Building mongoose project for test support.")
     FetchContent_Declare(mongoose 
                          GIT_REPOSITORY         https://github.com/cesanta/mongoose.git
-                         GIT_TAG                6.18
+                         GIT_TAG                80d74e9e341d541f71c0fa587d22cec89be32dd5 # the hash for 6.18
                          GIT_PROGRESS           TRUE
                          USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
     # We can not use FetchContent_MakeAvailable, since we need to patch mongoose to use CMake

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add the following to your `CMakeLists.txt`.
 
 ```cmake
 include(FetchContent)
-FetchContent_Declare(cpr GIT_REPOSITORY https://github.com/whoshuu/cpr.git)
+FetchContent_Declare(cpr GIT_REPOSITORY https://github.com/whoshuu/cpr.git GIT_TAG c8d33915dbd88ad6c92b258869b03aba06587ff9) # the commit hash for 1.5.0
 FetchContent_MakeAvailable(cpr)
 ```
 


### PR DESCRIPTION
I noticed the project is switching to using FetchContent instead of git submodules, but isn't using commit hashes to identify content the way submodules do.

This opens the system to a number of additional security concerns where an attacker could alter a dependency or the code of cpr itself for a developer using it, by using a signed certificate and dns spoofing, or compromising the github account of a developer and changing a tag, or working with github's servers themselves to offer differing data, all things that nations could do to gain advantage over each other at the expense of the citizens.  These are concerns that were severely mitigated with submodules, and could be comparably mitigated by using commit hashes instead of tags in FetchContsnt.

This PR adds a git commit hash to uses of FetchContent so that the content fetched can be verified correct.