### PR TITLE
Simplify Authentication classes and make them copyable/movable

### DIFF
--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -5,10 +5,8 @@ add_library(cpr
     cookies.cpp
     cprtypes.cpp
     curlholder.cpp
-    digest.cpp
     error.cpp
     multipart.cpp
-    ntlm.cpp
     parameters.cpp
     payload.cpp
     proxies.cpp

--- a/cpr/digest.cpp
+++ b/cpr/digest.cpp
@@ -1,9 +1,0 @@
-#include "cpr/digest.h"
-
-namespace cpr {
-
-const char* Digest::GetAuthString() const noexcept {
-    return Authentication::GetAuthString();
-}
-
-} // namespace cpr

--- a/cpr/ntlm.cpp
+++ b/cpr/ntlm.cpp
@@ -1,9 +1,0 @@
-#include "cpr/ntlm.h"
-
-namespace cpr {
-
-const char* NTLM::GetAuthString() const noexcept {
-    return Authentication::GetAuthString();
-}
-
-} // namespace cpr

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -18,7 +18,7 @@ class Authentication {
     }
     virtual ~Authentication() = default;
 
-    const char* GetAuthString() const noexcept;
+    virtual const char* GetAuthString() const noexcept;
 
   protected:
     std::string auth_string_;

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -15,7 +15,7 @@ class Authentication {
 
     const char* GetAuthString() const noexcept;
 
-  private:
+  protected:
     std::string auth_string_;
 };
 

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -9,17 +9,13 @@ namespace cpr {
 
 class Authentication {
   public:
-    Authentication(std::string&& username, std::string&& password)
-            : username_(std::move(username)),
-              password_(std::move(password)), auth_string_{this->username_ + ":" +
-                                                           this->password_} {}
+    Authentication(const std::string& username, const std::string& password)
+            : auth_string_{username + ":" + password} {}
     virtual ~Authentication() = default;
 
     const char* GetAuthString() const noexcept;
 
   private:
-    const std::string username_;
-    const std::string password_;
     const std::string auth_string_;
 };
 

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -12,10 +12,7 @@ class Authentication {
     Authentication(const std::string& username, const std::string& password)
             : auth_string_{username + ":" + password} {}
     Authentication(std::string&& username, std::string&& password)
-            : auth_string_{std::move(username)} {
-        auth_string_ += ':';
-        auth_string_ += std::move(password);
-    }
+            : auth_string_{std::move(username) + ":" + std::move(password)} {}
     virtual ~Authentication() = default;
 
     virtual const char* GetAuthString() const noexcept;

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -11,6 +11,11 @@ class Authentication {
   public:
     Authentication(const std::string& username, const std::string& password)
             : auth_string_{username + ":" + password} {}
+    Authentication(std::string&& username, std::string&& password)
+            : auth_string_{std::move(username)} {
+        auth_string_ += ':';
+        auth_string_ += std::move(password);
+    }
     virtual ~Authentication() = default;
 
     const char* GetAuthString() const noexcept;

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -16,7 +16,7 @@ class Authentication {
     const char* GetAuthString() const noexcept;
 
   private:
-    const std::string auth_string_;
+    std::string auth_string_;
 };
 
 } // namespace cpr

--- a/include/cpr/digest.h
+++ b/include/cpr/digest.h
@@ -7,12 +7,7 @@ namespace cpr {
 
 class Digest : public Authentication {
   public:
-    Digest(std::string&& username, std::string&& password)
-            : Authentication{std::move(username), std::move(password)} {}
-
-    ~Digest() override = default;
-
-    const char* GetAuthString() const noexcept;
+    using Authentication::Authentication;
 };
 
 } // namespace cpr

--- a/include/cpr/digest.h
+++ b/include/cpr/digest.h
@@ -7,7 +7,8 @@ namespace cpr {
 
 class Digest : public Authentication {
   public:
-    using Authentication::Authentication;
+    Digest(const std::string& username, const std::string& password)
+            : Authentication{username, password} {}
 };
 
 } // namespace cpr

--- a/include/cpr/ntlm.h
+++ b/include/cpr/ntlm.h
@@ -8,7 +8,8 @@ namespace cpr {
 
 class NTLM : public Authentication {
   public:
-    using Authentication::Authentication;
+    NTLM(const std::string& username, const std::string& password)
+            : Authentication{username, password} {}
 };
 
 } // namespace cpr

--- a/include/cpr/ntlm.h
+++ b/include/cpr/ntlm.h
@@ -8,11 +8,7 @@ namespace cpr {
 
 class NTLM : public Authentication {
   public:
-    template <typename UserType, typename PassType>
-    NTLM(UserType&& username, PassType&& password)
-            : Authentication{std::move(username), std::move(password)} {}
-
-    const char* GetAuthString() const noexcept;
+    using Authentication::Authentication;
 };
 
 } // namespace cpr


### PR DESCRIPTION
I ran into an issue where I want to be able to assign a member Authentication variable from a provided Authentication value, but that is impossible because of the `const` private members.  Removing the `const` fixes this (and since they are already private doesn't change anything), but while I was here I also noticed some unnecessary related code, so simplified that as well.  See individual commit messages for details.