### PR TITLE
Add missing Session methods

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -652,6 +652,9 @@ void Session::SetBody(const Body& body) { pimpl_->SetBody(body); }
 void Session::SetBody(Body&& body) { pimpl_->SetBody(std::move(body)); }
 void Session::SetLowSpeed(const LowSpeed& low_speed) { pimpl_->SetLowSpeed(low_speed); }
 void Session::SetVerifySsl(const VerifySsl& verify) { pimpl_->SetVerifySsl(verify); }
+void Session::SetUnixSocket(const UnixSocket& unix_socket) { pimpl_->SetUnixSocket(unix_socket); }
+void Session::SetSslOptions(const SslOptions& options) { pimpl_->SetSslOptions(options); }
+void Session::SetVerbose(const Verbose& verbose) { pimpl_->SetVerbose(verbose); }
 void Session::SetOption(const Url& url) { pimpl_->SetUrl(url); }
 void Session::SetOption(const Parameters& parameters) { pimpl_->SetParameters(parameters); }
 void Session::SetOption(Parameters&& parameters) { pimpl_->SetParameters(std::move(parameters)); }


### PR DESCRIPTION
SetUnixSocket, SetSslOptions, and SetVerbose are declared in the Session
header but missing implementations (thus causing linking failures if
attempting to use any of them) -- only the SetOption(...) overloads had
implementations.  This adds the missing implementations.