### PR TITLE
fix: Don't search for invalid cURL components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,11 +55,11 @@ include(cmake/code_coverage.cmake)
 
 # Curl configuration
 if(USE_SYSTEM_CURL)
-    find_package(CURL COMPONENTS PROTOCOLS HTTP HTTPS FEATURES SSL)
+    find_package(CURL COMPONENTS HTTP HTTPS SSL)
     if (CURL_FOUND)
         set(SSL_ENABLED ON CACHE INTERNAL "" FORCE)
     else()
-        find_package(CURL COMPONENTS PROTOCOLS HTTP)
+        find_package(CURL COMPONENTS HTTP)
         if(CURL_FOUND)
             set(SSL_ENABLED OFF CACHE INTERNAL "" FORCE)
         endif()


### PR DESCRIPTION
`PROTOCOLS` and `FEATURES` aren't real cURL package components. AFAICT neither CMake-bundled FindCURL module nor cURL-provided config package (when building it with CMake) support those components, and both fail to find the library when they are passed.