### PR TITLE
Change external projects download method to https

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,9 +90,8 @@ if(NOT USE_SYSTEM_CURL OR NOT CURL_FOUND)
     # Show progress of FetchContent:
     set(FETCHCONTENT_QUIET OFF CACHE INTERNAL "" FORCE)
     FetchContent_Declare(curl
-                         GIT_REPOSITORY         https://github.com/curl/curl.git
-                         GIT_TAG                b81e0b07784dc4c1e8d0a86194b9d28776d071c0 # the hash for curl-7_69_1
-                         GIT_PROGRESS           TRUE
+                         URL                    https://github.com/curl/curl/releases/download/curl-7_69_1/curl-7.69.1.tar.xz
+                         URL_HASH               SHA256=03c7d5e6697f7b7e40ada1b2256e565a555657398e6c1fcfa4cb251ccd819d4f # the file hash for curl-7.69.1.tar.xz
                          USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
 
     FetchContent_MakeAvailable(curl)
@@ -124,9 +123,8 @@ if(BUILD_CPR_TESTS)
             set(gtest_force_shared_crt ON CACHE BOOL "Force gtest to use the shared c runtime")
         endif()
         FetchContent_Declare(googletest
-                             GIT_REPOSITORY         https://github.com/google/googletest.git
-                             GIT_TAG                703bd9caab50b139428cea1aaff9974ebee5742e # the hash for release-1.10.0
-                             GIT_PROGRESS           TRUE
+                             URL                    https://github.com/google/googletest/archive/release-1.10.0.tar.gz
+                             URL_HASH               SHA256=9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb # the file hash for release-1.10.0.tar.gz
                              USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
         FetchContent_MakeAvailable(googletest)
         
@@ -158,9 +156,8 @@ if(BUILD_CPR_TESTS)
     endif()
 
     FetchContent_Declare(mongoose 
-                         GIT_REPOSITORY         https://github.com/cesanta/mongoose.git
-                         GIT_TAG                80d74e9e341d541f71c0fa587d22cec89be32dd5 # the hash for 6.18
-                         GIT_PROGRESS           TRUE
+                         URL                    https://github.com/cesanta/mongoose/archive/6.18.tar.gz
+                         URL_HASH               SHA256=f5c10346abc9c72f7cac7885d853ca064fb09aad57580433941a8fd7a3543769 # the hash for 6.18.tar.gz
                          USES_TERMINAL_DOWNLOAD TRUE)   # <---- This is needed only for Ninja to show download progress
     # We can not use FetchContent_MakeAvailable, since we need to patch mongoose to use CMake
     if (NOT mongoose_POPULATED)


### PR DESCRIPTION
Since CMake FetchContent with git would clone the whole repository,
using http to download only specific version would save a lot of
time and space.

Related issue #439 

Signed-off-by: Yibai Zhang <xm1994@gmail.com>