### PR TITLE
Add Parameters::AddParameter overload without CurlHolder

### DIFF
--- a/cpr/CMakeLists.txt
+++ b/cpr/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(cpr
     auth.cpp
     cookies.cpp
     cprtypes.cpp
+    curl_container.cpp
     curlholder.cpp
     error.cpp
     multipart.cpp

--- a/cpr/curl_container.cpp
+++ b/cpr/curl_container.cpp
@@ -1,0 +1,62 @@
+#include "cpr/curl_container.h"
+
+
+namespace cpr {
+
+
+template<class T>
+CurlContainer<T>::CurlContainer(const std::initializer_list<T>& containerList) : containerList_(containerList) {
+
+}
+
+
+template<class T>
+void CurlContainer<T>::Add(const std::initializer_list<T>& containerList) {
+    for(const auto& element : containerList) {
+        containerList_.push_back(std::move(element));
+    }
+}
+
+template<class T>
+void CurlContainer<T>::Add(const T& element) {
+    containerList_.push_back(std::move(element));
+}
+
+template<>
+const std::string CurlContainer<Parameter>::GetContent(const CurlHolder& holder) const {
+    std::string content{};
+    for(const auto& parameter : containerList_) {
+        if (!content.empty()) {
+            content += "&";
+        }
+
+        std::string escapedKey = holder.urlEncode(parameter.key);
+        if (parameter.value.empty()) {
+            content += escapedKey;
+        } else {
+            std::string escapedValue = holder.urlEncode(parameter.value);
+            content += escapedKey + "=" + escapedValue;
+        }
+    };
+
+    return content;
+}
+
+template<>
+const std::string CurlContainer<Pair>::GetContent(const CurlHolder& holder) const {
+    std::string content{};
+    for(const auto& element : containerList_) {
+        if (!content.empty()) {
+            content += "&";
+        }
+        std::string escaped = holder.urlEncode(element.value);
+        content += element.key + "=" + escaped;
+    }
+
+    return content;
+}
+
+template class CurlContainer<Pair>;
+template class CurlContainer<Parameter>;
+
+} // namespace cpr

--- a/cpr/parameters.cpp
+++ b/cpr/parameters.cpp
@@ -7,32 +7,8 @@
 
 namespace cpr {
 
-Parameters::Parameters(const std::initializer_list<Parameter>& parameters) {
-    // Create a temporary CurlHolder for URL encoding:
-    CurlHolder holder;
-    for (const auto& parameter : parameters) {
-        AddParameter(parameter, holder);
-    }
-}
+Parameters::Parameters(const std::initializer_list<Parameter>& parameters) : CurlContainer<Parameter>(parameters) {
 
-void Parameters::AddParameter(const Parameter& parameter) {
-    // Create a temporary CurlHolder for URL encoding:
-    CurlHolder holder;
-    AddParameter(parameter, holder);
-}
-
-void Parameters::AddParameter(const Parameter& parameter, const CurlHolder& holder) {
-    if (!content.empty()) {
-        content += "&";
-    }
-
-    std::string escapedKey = holder.urlEncode(parameter.key);
-    if (parameter.value.empty()) {
-        content += escapedKey;
-    } else {
-        std::string escapedValue = holder.urlEncode(parameter.value);
-        content += escapedKey + "=" + escapedValue;
-    }
 }
 
 } // namespace cpr

--- a/cpr/parameters.cpp
+++ b/cpr/parameters.cpp
@@ -15,6 +15,12 @@ Parameters::Parameters(const std::initializer_list<Parameter>& parameters) {
     }
 }
 
+void Parameters::AddParameter(const Parameter& parameter) {
+    // Create a temporary CurlHolder for URL encoding:
+    CurlHolder holder;
+    AddParameter(parameter, holder);
+}
+
 void Parameters::AddParameter(const Parameter& parameter, const CurlHolder& holder) {
     if (!content.empty()) {
         content += "&";

--- a/cpr/payload.cpp
+++ b/cpr/payload.cpp
@@ -7,14 +7,8 @@
 
 namespace cpr {
 
-Payload::Payload(const std::initializer_list<Pair>& pairs) : Payload(begin(pairs), end(pairs)) {}
+Payload::Payload(const std::initializer_list<Pair>& pairs) : CurlContainer<Pair>(pairs) {
 
-void Payload::AddPair(const Pair& pair, const CurlHolder& holder) {
-    if (!content.empty()) {
-        content += "&";
-    }
-    std::string escaped = holder.urlEncode(pair.value);
-    content += pair.key + "=" + escaped;
 }
 
 } // namespace cpr

--- a/include/cpr/curl_container.h
+++ b/include/cpr/curl_container.h
@@ -1,0 +1,54 @@
+#ifndef CURL_CONTAINER_H
+#define CURL_CONTAINER_H
+
+#include <initializer_list>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "cpr/curlholder.h"
+
+
+namespace cpr {
+
+struct Parameter {
+    Parameter(const std::string& key, const std::string& value)
+            : key{key}, value{value} {}
+    Parameter(std::string&& key, std::string&& value)
+            : key{std::move(key)}, value{std::move(value)} {}
+
+    std::string key;
+    std::string value;
+};
+
+struct Pair {
+    Pair(const std::string& p_key, const std::string& p_value)
+            : key(p_key), value(p_value) {}
+    Pair(std::string&& p_key, std::string&& p_value)
+            : key(std::move(p_key)), value(std::move(p_value)) {}
+
+    std::string key;
+    std::string value;
+};
+
+
+template<class T>
+class CurlContainer {
+  public:
+    CurlContainer() = default;
+    CurlContainer(const std::initializer_list<T>&);
+
+  public:
+    void Add(const std::initializer_list<T>&);
+    void Add(const T&);
+
+  public:
+    const std::string GetContent(const CurlHolder&) const;
+
+  protected:
+    std::vector<T> containerList_;
+};
+
+} // namespace cpr
+
+#endif //

--- a/include/cpr/parameters.h
+++ b/include/cpr/parameters.h
@@ -4,31 +4,16 @@
 #include <initializer_list>
 #include <memory>
 #include <string>
+#include <vector>
 
-#include "cpr/curlholder.h"
+#include "cpr/curl_container.h"
 
 namespace cpr {
 
-struct Parameter {
-    Parameter(const std::string& key, const std::string& value)
-            : key{key}, value{value} {}
-    Parameter(std::string&& key, std::string&& value)
-            : key{std::move(key)}, value{std::move(value)} {}
-
-    std::string key;
-    std::string value;
-};
-
-class Parameters {
+class Parameters : public CurlContainer<Parameter> {
   public:
     Parameters() = default;
     Parameters(const std::initializer_list<Parameter>& parameters);
-
-    void AddParameter(const Parameter& parameter);
-
-    void AddParameter(const Parameter& parameter, const CurlHolder& holder);
-
-    std::string content;
 };
 
 } // namespace cpr

--- a/include/cpr/parameters.h
+++ b/include/cpr/parameters.h
@@ -24,6 +24,8 @@ class Parameters {
     Parameters() = default;
     Parameters(const std::initializer_list<Parameter>& parameters);
 
+    void AddParameter(const Parameter& parameter);
+
     void AddParameter(const Parameter& parameter, const CurlHolder& holder);
 
     std::string content;

--- a/include/cpr/payload.h
+++ b/include/cpr/payload.h
@@ -6,36 +6,21 @@
 #include <memory>
 #include <string>
 
-#include "cpr/curlholder.h"
+#include "cpr/curl_container.h"
 #include <utility>
 
 namespace cpr {
 
-struct Pair {
-    Pair(const std::string& p_key, const std::string& p_value)
-            : key(p_key), value(p_value) {}
-    Pair(std::string&& p_key, std::string&& p_value)
-            : key(std::move(p_key)), value(std::move(p_value)) {}
 
-    std::string key;
-    std::string value;
-};
-
-class Payload {
+class Payload : public CurlContainer<Pair> {
   public:
     template <class It>
     Payload(const It begin, const It end) {
-        // Create a temporary CurlHolder for URL encoding:
-        CurlHolder holder;
         for (It pair = begin; pair != end; ++pair) {
-            AddPair(*pair, holder);
+            Add(*pair);
         }
     }
     Payload(const std::initializer_list<Pair>& pairs);
-
-    void AddPair(const Pair& pair, const CurlHolder& holder);
-
-    std::string content;
 };
 
 } // namespace cpr

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -173,8 +173,8 @@ TEST(ParameterTests, MultipleDynamicParametersTest) {
     Parameters parameters{{"key", "value"}};
     // Create a temporary CurlHolder for URL encoding:
     CurlHolder holder;
-    parameters.AddParameter({"hello", "world"}, holder);
-    parameters.AddParameter({"test", "case"});
+    parameters.Add({"hello", "world"});
+    parameters.Add({"test", "case"});
     Response response = cpr::Get(url, parameters);
     std::string expected_text{"Hello world!"};
     EXPECT_EQ(expected_text, response.text);

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -174,7 +174,7 @@ TEST(ParameterTests, MultipleDynamicParametersTest) {
     // Create a temporary CurlHolder for URL encoding:
     CurlHolder holder;
     parameters.AddParameter({"hello", "world"}, holder);
-    parameters.AddParameter({"test", "case"}, holder);
+    parameters.AddParameter({"test", "case"});
     Response response = cpr::Get(url, parameters);
     std::string expected_text{"Hello world!"};
     EXPECT_EQ(expected_text, response.text);

--- a/test/get_tests.cpp
+++ b/test/get_tests.cpp
@@ -171,8 +171,6 @@ TEST(ParameterTests, MultipleParametersTest) {
 TEST(ParameterTests, MultipleDynamicParametersTest) {
     Url url{server->GetBaseUrl() + "/hello.html"};
     Parameters parameters{{"key", "value"}};
-    // Create a temporary CurlHolder for URL encoding:
-    CurlHolder holder;
     parameters.Add({"hello", "world"});
     parameters.Add({"test", "case"});
     Response response = cpr::Get(url, parameters);

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -33,7 +33,7 @@ TEST(UrlEncodedPostTests, UrlPostAddPayloadPair) {
     Payload payload{{"x", "1"}};
     // Create a temporary CurlHolder for URL encoding:
     CurlHolder holder;
-    payload.AddPair({"y", "2"}, holder);
+    payload.Add({"y", "2"});
     Response response = cpr::Post(url, payload);
     std::string expected_text{
             "{\n"

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -31,8 +31,6 @@ TEST(UrlEncodedPostTests, UrlPostSingleTest) {
 TEST(UrlEncodedPostTests, UrlPostAddPayloadPair) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
     Payload payload{{"x", "1"}};
-    // Create a temporary CurlHolder for URL encoding:
-    CurlHolder holder;
     payload.Add({"y", "2"});
     Response response = cpr::Post(url, payload);
     std::string expected_text{

--- a/test/structures_tests.cpp
+++ b/test/structures_tests.cpp
@@ -13,7 +13,7 @@ TEST(PayloadTests, UseStringVariableTest) {
     Payload payload {{"key1", value1}, {key2, "world"}};
 
     std::string expected = "key1=hello&key2=world";
-    EXPECT_EQ(payload.content, expected);
+    EXPECT_EQ(payload.GetContent(CurlHolder()), expected);
 }
 
 TEST(ParametersTests, UseStringVariableTest) {
@@ -22,7 +22,7 @@ TEST(ParametersTests, UseStringVariableTest) {
     Parameters parameters {{"key1", value1}, {key2, "world"}};
 
     std::string expected = "key1=hello&key2=world";
-    EXPECT_EQ(parameters.content, expected);
+    EXPECT_EQ(parameters.GetContent(CurlHolder()), expected);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
To use the current `void Parameters::AddParameter(const Parameter& parameter, const CurlHolder& holder)` requires to create a `CurlHolder` object before to call the method.

This pull request consists in overloading the method by requiring the `const Parameter& parameter` argument only. The `CurlHolder` object is now created before to call the original method `void Parameters::AddParameter(const Parameter& parameter, const CurlHolder& holder)`.