### PR TITLE
Implement Url Decoding

### DIFF
--- a/cpr/curlholder.cpp
+++ b/cpr/curlholder.cpp
@@ -38,4 +38,15 @@ std::string CurlHolder::urlEncode(const std::string& s) const {
     }
     return "";
 }
+
+std::string CurlHolder::urlDecode(const std::string& s) const {
+    assert(handle);
+    char* output = curl_easy_unescape(handle, s.c_str(), s.length(), nullptr);
+    if (output) {
+        std::string result = output;
+        curl_free(output);
+        return result;
+    }
+    return "";
+}
 } // namespace cpr

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -146,7 +146,7 @@ std::string urlEncode(const std::string& s) {
 
 /**
  * Creates a temporary CurlHolder object and uses it to unescape the given string.
- * If you plan to use this methode on a regular basis think about creating CurlHolder
+ * If you plan to use this methode on a regular basis think about creating a CurlHolder
  * object and calling urlDecode(std::string) on it.
  *
  * Example:

--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -144,5 +144,20 @@ std::string urlEncode(const std::string& s) {
     return holder.urlEncode(s);
 }
 
+/**
+ * Creates a temporary CurlHolder object and uses it to unescape the given string.
+ * If you plan to use this methode on a regular basis think about creating CurlHolder
+ * object and calling urlDecode(std::string) on it.
+ *
+ * Example:
+ * CurlHolder holder;
+ * std::string input = "Hello%20World%21";
+ * std::string result = holder.urlDecode(input);
+ **/
+std::string urlDecode(const std::string& s) {
+    CurlHolder holder; // Create a temporary new holder for URL decoding
+    return holder.urlDecode(s);
+}
+
 } // namespace util
 } // namespace cpr

--- a/include/cpr/curlholder.h
+++ b/include/cpr/curlholder.h
@@ -31,6 +31,11 @@ struct CurlHolder {
      * Uses curl_easy_escape(...) for escaping the given string.
      **/
     std::string urlEncode(const std::string& s) const;
+
+    /**
+     * Uses curl_easy_unescape(...) for unescaping the given string.
+     **/
+    std::string urlDecode(const std::string& s) const;
 };
 } // namespace cpr
 

--- a/include/cpr/util.h
+++ b/include/cpr/util.h
@@ -29,6 +29,7 @@ int progressUserFunction(const ProgressCallback * progress, curl_off_t dltotal, 
 int debugUserFunction(CURL *handle, curl_infotype type, char * data, size_t size, const DebugCallback * debug);
 std::vector<std::string> split(const std::string& to_split, char delimiter);
 std::string urlEncode(const std::string& s);
+std::string urlDecode(const std::string& s);
 
 } // namespace util
 } // namespace cpr

--- a/test/util_tests.cpp
+++ b/test/util_tests.cpp
@@ -146,6 +146,20 @@ TEST(UtilUrlEncodeTests, AsciiEncoderTest) {
     EXPECT_EQ(result, expected);
 }
 
+TEST(UtilUrlDecodeTests, UnicodeDecoderTest) {
+    std::string input = "%E4%B8%80%E4%BA%8C%E4%B8%89";
+    std::string result = util::urlDecode(input);
+    std::string expected = "一二三";
+    EXPECT_EQ(result, expected);
+}
+
+TEST(UtilUrlDecodeTests, AsciiDecoderTest) {
+    std::string input = "Hello%20World%21";
+    std::string result = util::urlDecode(input);
+    std::string expected = "Hello World!";
+    EXPECT_EQ(result, expected);
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
I found myself needing to decode text. This function does the opposite of `cpr::util::urlEncode(const std::string& s)` using `curl_easy_unescape`.

Signed-off-by: Luca Schlecker <luca.schlecker@hotmail.com>