### PR TITLE
add guards for curl version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,28 @@ on:
     branches: [ master ]
 
 jobs:
-  ubuntu-gcc-ssl:
-    runs-on: ubuntu-latest
+  ubuntu-20-gcc-ssl:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.2.0
+      with:
+        submodules: true
+    - name: Install libssl-dev
+      run: sudo apt install libssl-dev
+    - name: "[Release g++] Build & Test"
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{github.workspace}}/build
+        source-dir: ${{github.workspace}}
+        cc: gcc
+        cxx: g++
+        build-type: Release
+        run-test: true
+        ctest-options: -V
+
+  ubuntu-18-gcc-ssl:
+    runs-on: ubuntu-18.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2.2.0
@@ -26,8 +46,8 @@ jobs:
         run-test: true
         ctest-options: -V
     
-  ubuntu-gcc-ssl-address-leak-undefined-behavior-sanitizer:
-    runs-on: ubuntu-latest
+  ubuntu-18-gcc-ssl-address-leak-undefined-behavior-sanitizer:
+    runs-on: ubuntu-18.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2.2.0
@@ -48,8 +68,8 @@ jobs:
         run-test: true
         ctest-options: -V
 
-  ubuntu-gcc-ssl-thread-sanitizer:
-    runs-on: ubuntu-latest
+  ubuntu-18-gcc-ssl-thread-sanitizer:
+    runs-on: ubuntu-18.04
     if: ${{ false }} # Disabled for now until all problems are resolved
     steps:
     - name: Checkout
@@ -71,8 +91,8 @@ jobs:
         run-test: true
         ctest-options: -V
   
-  ubuntu-clang-ssl:
-    runs-on: ubuntu-latest
+  ubuntu-18-clang-ssl:
+    runs-on: ubuntu-18.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2.2.0
@@ -87,6 +107,26 @@ jobs:
         source-dir: ${{github.workspace}}
         cc: clang
         cxx: clang++
+        build-type: Release
+        run-test: true
+        ctest-options: -V
+
+  ubuntu-16-gcc-ssl:
+    runs-on: ubuntu-16.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.2.0
+      with:
+        submodules: true
+    - name: Install libssl-dev
+      run: sudo apt install libssl-dev
+    - name: "[Release g++] Build & Test"
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{github.workspace}}/build
+        source-dir: ${{github.workspace}}
+        cc: gcc
+        cxx: g++
         build-type: Release
         run-test: true
         ctest-options: -V

--- a/cpr/response.cpp
+++ b/cpr/response.cpp
@@ -13,8 +13,16 @@ Response::Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text,
     char* url_string{nullptr};
     curl_easy_getinfo(curl_->handle, CURLINFO_EFFECTIVE_URL, &url_string);
     url = Url(url_string);
+#if LUBCURL_VERSION_NUM < 0x075500
+    double downloaded_bytes_double, uploaded_bytes_double;
+    curl_easy_getinfo(curl_->handle, CURLINFO_SIZE_DOWNLOAD, &downloaded_bytes_double);
+    curl_easy_getinfo(curl_->handle, CURLINFO_SIZE_UPLOAD, &uploaded_bytes_double);
+    downloaded_bytes = downloaded_bytes_double;
+    uploaded_bytes = uploaded_bytes_double;
+#else
     curl_easy_getinfo(curl_->handle, CURLINFO_SIZE_DOWNLOAD_T, &downloaded_bytes);
     curl_easy_getinfo(curl_->handle, CURLINFO_SIZE_UPLOAD_T, &uploaded_bytes);
+#endif
     curl_easy_getinfo(curl_->handle, CURLINFO_REDIRECT_COUNT, &redirect_count);
 }
 

--- a/cpr/response.cpp
+++ b/cpr/response.cpp
@@ -13,15 +13,15 @@ Response::Response(std::shared_ptr<CurlHolder> curl, std::string&& p_text,
     char* url_string{nullptr};
     curl_easy_getinfo(curl_->handle, CURLINFO_EFFECTIVE_URL, &url_string);
     url = Url(url_string);
-#if LUBCURL_VERSION_NUM < 0x075500
+#if LIBCURL_VERSION_NUM >= 0x073700
+    curl_easy_getinfo(curl_->handle, CURLINFO_SIZE_DOWNLOAD_T, &downloaded_bytes);
+    curl_easy_getinfo(curl_->handle, CURLINFO_SIZE_UPLOAD_T, &uploaded_bytes);
+#else
     double downloaded_bytes_double, uploaded_bytes_double;
     curl_easy_getinfo(curl_->handle, CURLINFO_SIZE_DOWNLOAD, &downloaded_bytes_double);
     curl_easy_getinfo(curl_->handle, CURLINFO_SIZE_UPLOAD, &uploaded_bytes_double);
     downloaded_bytes = downloaded_bytes_double;
     uploaded_bytes = uploaded_bytes_double;
-#else
-    curl_easy_getinfo(curl_->handle, CURLINFO_SIZE_DOWNLOAD_T, &downloaded_bytes);
-    curl_easy_getinfo(curl_->handle, CURLINFO_SIZE_UPLOAD_T, &uploaded_bytes);
 #endif
     curl_easy_getinfo(curl_->handle, CURLINFO_REDIRECT_COUNT, &redirect_count);
 }

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -365,7 +365,9 @@ void Session::Impl::SetSslOptions(const SslOptions& opts) {
 #endif
     curl_easy_setopt(curl_->handle, CURLOPT_SSL_VERIFYPEER, opts.verify_peer ? ON : OFF);
     curl_easy_setopt(curl_->handle, CURLOPT_SSL_VERIFYHOST, opts.verify_host ? 2L : 0L);
+#if LIBCURL_VERSION_NUM >= 0x074100
     curl_easy_setopt(curl_->handle, CURLOPT_SSL_VERIFYSTATUS, opts.verify_status ? ON : OFF);
+#endif
     curl_easy_setopt(curl_->handle, CURLOPT_SSLVERSION,
                      opts.ssl_version
 #if SUPPORT_MAX_TLS_VERSION

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -365,7 +365,7 @@ void Session::Impl::SetSslOptions(const SslOptions& opts) {
 #endif
     curl_easy_setopt(curl_->handle, CURLOPT_SSL_VERIFYPEER, opts.verify_peer ? ON : OFF);
     curl_easy_setopt(curl_->handle, CURLOPT_SSL_VERIFYHOST, opts.verify_host ? 2L : 0L);
-#if LIBCURL_VERSION_NUM >= 0x074100
+#if LIBCURL_VERSION_NUM >= 0x072900
     curl_easy_setopt(curl_->handle, CURLOPT_SSL_VERIFYSTATUS, opts.verify_status ? ON : OFF);
 #endif
     curl_easy_setopt(curl_->handle, CURLOPT_SSLVERSION,


### PR DESCRIPTION
I haven't actually been able to compile 1.5.2 for my system and projects yet (still using 1.4.0), but while attempting to I bumped into this, which might be missing.