### PR TITLE
Update verbose.h

### DIFF
--- a/include/cpr/verbose.h
+++ b/include/cpr/verbose.h
@@ -1,8 +1,6 @@
 #ifndef CPR_VERBOSE_H_
 #define CPR_VERBOSE_H_
 
-#include <cstdbool>
-
 namespace cpr {
 
 class Verbose {


### PR DESCRIPTION
Removed a (unused?) cstdbool include that caused C++17 deprecation errors when building on MSVC.

[https://en.cppreference.com/w/cpp/header/cstdbool](Source)