### PR TITLE
Fixed implicit conversion

### DIFF
--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -3,7 +3,7 @@
 namespace cpr {
 std::string Cookies::GetEncoded(const CurlHolder& holder) const {
     std::stringstream stream;
-    for (const auto& item : map_) {
+    for (const std::pair<const std::string, std::string>& item : map_) {
         // Depending on if encoding is set to "true", we will URL-encode cookies
         stream << (encode ? holder.urlEncode(item.first) : item.first) << "=";
 

--- a/cpr/cookies.cpp
+++ b/cpr/cookies.cpp
@@ -3,7 +3,7 @@
 namespace cpr {
 std::string Cookies::GetEncoded(const CurlHolder& holder) const {
     std::stringstream stream;
-    for (const std::pair<std::string, std::string>& item : map_) {
+    for (const auto& item : map_) {
         // Depending on if encoding is set to "true", we will URL-encode cookies
         stream << (encode ? holder.urlEncode(item.first) : item.first) << "=";
 


### PR DESCRIPTION
std::map automatically const-ify the key type, so this changed for each
caused an inplicit conversion.