### PR TITLE
Removed explict settings of HTTP type for Get and Post requets

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -451,7 +451,7 @@ Response Session::Impl::Download(std::ofstream& file) {
 
 Response Session::Impl::Get() {
     curl_easy_setopt(curl_->handle, CURLOPT_NOBODY, 0L);
-    curl_easy_setopt(curl_->handle, CURLOPT_CUSTOMREQUEST, "GET");
+    curl_easy_setopt(curl_->handle, CURLOPT_CUSTOMREQUEST, nullptr);
 
     return makeRequest();
 }
@@ -479,7 +479,7 @@ Response Session::Impl::Patch() {
 
 Response Session::Impl::Post() {
     curl_easy_setopt(curl_->handle, CURLOPT_NOBODY, 0L);
-    curl_easy_setopt(curl_->handle, CURLOPT_CUSTOMREQUEST, "POST");
+    curl_easy_setopt(curl_->handle, CURLOPT_CUSTOMREQUEST, nullptr);
 
     // In case there is no body or payload set it to an empty post:
     if (!hasBodyOrPayload_) {


### PR DESCRIPTION
Setting http request types supported by Curl is dicouraged according to the documentation.
See:
https://curl.se/libcurl/c/CURLOPT_CUSTOMREQUEST.html
https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/
for more details.

This patch might be applicable to other http requests currently supported.
But I don't think that my understanding of the current usage is good enough for making those changes.

Thanks.
