### PR TITLE
Problem 491 was fixed.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,8 +12,13 @@ else ()
                 abstractServer.cpp
                 httpServer.cpp)
 endif()
-target_link_libraries(test_server PRIVATE Threads::Threads cpr::cpr GTest::GTest
-                                             PUBLIC mongoose)
+if(WIN32)
+    target_link_libraries(test_server PRIVATE Threads::Threads cpr::cpr GTest::GTest
+                                                PUBLIC mongoose ws2_32 wsock32)
+else()
+    target_link_libraries(test_server PRIVATE Threads::Threads cpr::cpr GTest::GTest
+                                                PUBLIC mongoose)
+endif()
 
 macro(add_cpr_test _TEST_NAME)
     add_executable(${_TEST_NAME}_tests ${_TEST_NAME}_tests.cpp)


### PR DESCRIPTION
The problem was the lack of linking of necessary libraries for Windows. The problem occurred during the construction of the tests, at least there it was noticed.
