### PR TITLE
V1.5.2 pre

### DIFF
--- a/cpr/curlholder.cpp
+++ b/cpr/curlholder.cpp
@@ -2,8 +2,7 @@
 #include <cassert>
 
 namespace cpr {
-// NOLINTNEXTLINE (cert-err58-cpp)
-std::mutex curl_easy_init_mutex_;
+std::mutex CurlHolder::curl_easy_init_mutex_{};
 
 CurlHolder::CurlHolder() {
     /**

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -312,7 +312,8 @@ void Session::Impl::SetBody(Body&& body) {
     hasBodyOrPayload_ = true;
     auto curl = curl_->handle;
     if (curl) {
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, body.str().length());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE,
+                         static_cast<curl_off_t>(body.str().length()));
         curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, body.c_str());
     }
 }
@@ -321,7 +322,8 @@ void Session::Impl::SetBody(const Body& body) {
     hasBodyOrPayload_ = true;
     auto curl = curl_->handle;
     if (curl) {
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, body.str().length());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE,
+                         static_cast<curl_off_t>(body.str().length()));
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     }
 }

--- a/include/cpr/auth.h
+++ b/include/cpr/auth.h
@@ -9,7 +9,7 @@ namespace cpr {
 
 class Authentication {
   public:
-    Authentication(const std::string&& username, const std::string&& password)
+    Authentication(std::string&& username, std::string&& password)
             : username_(std::move(username)),
               password_(std::move(password)), auth_string_{this->username_ + ":" +
                                                            this->password_} {}

--- a/include/cpr/body.h
+++ b/include/cpr/body.h
@@ -12,7 +12,7 @@ class Body : public StringHolder<Body> {
   public:
     Body() : StringHolder<Body>() {}
     Body(const std::string& body) : StringHolder<Body>(body) {}
-    Body(const std::string&& body) : StringHolder<Body>(std::move(body)) {}
+    Body(std::string&& body) : StringHolder<Body>(std::move(body)) {}
     Body(const char* body) : StringHolder<Body>(body) {}
     Body(const char* str, size_t len) : StringHolder<Body>(str, len) {}
     Body(const std::initializer_list<std::string> args) : StringHolder<Body>(args) {}

--- a/include/cpr/cprtypes.h
+++ b/include/cpr/cprtypes.h
@@ -14,7 +14,7 @@ class StringHolder {
   public:
     StringHolder() {}
     explicit StringHolder(const std::string& str) : str_(str) {}
-    explicit StringHolder(const std::string&& str) : str_(std::move(str)) {}
+    explicit StringHolder(std::string&& str) : str_(std::move(str)) {}
     explicit StringHolder(const char* str) : str_(str) {}
     StringHolder(const char* str, size_t len) : str_(str, len) {}
     StringHolder(const std::initializer_list<std::string> args) {
@@ -93,7 +93,7 @@ class Url : public StringHolder<Url> {
   public:
     Url() : StringHolder<Url>() {}
     Url(const std::string& url) : StringHolder<Url>(url) {}
-    Url(const std::string&& url) : StringHolder<Url>(std::move(url)) {}
+    Url(std::string&& url) : StringHolder<Url>(std::move(url)) {}
     Url(const char* url) : StringHolder<Url>(url) {}
     Url(const char* str, size_t len) : StringHolder<Url>(std::string(str, len)) {}
     Url(const std::initializer_list<std::string> args) : StringHolder<Url>(args) {}

--- a/include/cpr/curlholder.h
+++ b/include/cpr/curlholder.h
@@ -7,17 +7,18 @@
 #include <curl/curl.h>
 
 namespace cpr {
-
-/**
- * Mutex for curl_easy_init().
- * curl_easy_init() is not thread save.
- * References:
- * https://curl.haxx.se/libcurl/c/curl_easy_init.html
- * https://curl.haxx.se/libcurl/c/threadsafe.html
- **/
-extern std::mutex curl_easy_init_mutex_;
-
 struct CurlHolder {
+  private:
+    /**
+     * Mutex for curl_easy_init().
+     * curl_easy_init() is not thread save.
+     * References:
+     * https://curl.haxx.se/libcurl/c/curl_easy_init.html
+     * https://curl.haxx.se/libcurl/c/threadsafe.html
+     **/
+    static std::mutex curl_easy_init_mutex_;
+
+  public:
     CURL* handle{nullptr};
     struct curl_slist* chunk{nullptr};
     struct curl_httppost* formpost{nullptr};

--- a/include/cpr/digest.h
+++ b/include/cpr/digest.h
@@ -7,7 +7,7 @@ namespace cpr {
 
 class Digest : public Authentication {
   public:
-    Digest(const std::string&& username, const std::string&& password)
+    Digest(std::string&& username, std::string&& password)
             : Authentication{std::move(username), std::move(password)} {}
 
     ~Digest() override = default;

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -10,7 +10,7 @@
 namespace cpr {
 
 struct File {
-    explicit File(const std::string&& filepath) : filepath(std::move(filepath)) {}
+    explicit File(std::string&& filepath) : filepath(std::move(filepath)) {}
     explicit File(const std::string& filepath) : filepath(filepath) {}
     const std::string filepath;
 };
@@ -19,7 +19,7 @@ struct Buffer {
     typedef const unsigned char* data_t;
 
     template <typename Iterator>
-    explicit Buffer(Iterator begin, Iterator end, const std::string&& filename)
+    explicit Buffer(Iterator begin, Iterator end, std::string&& filename)
             : data{reinterpret_cast<data_t>(&(*begin))}, datalen{static_cast<unsigned long>(
                                                                  std::distance(begin, end))},
               filename(std::move(filename)) {

--- a/include/cpr/ssl_options.h
+++ b/include/cpr/ssl_options.h
@@ -80,7 +80,7 @@ namespace ssl {
 // set SSL client certificate
 class CertFile {
   public:
-    CertFile(const std::string&& p_filename) : filename(std::move(p_filename)) {}
+    CertFile(std::string&& p_filename) : filename(std::move(p_filename)) {}
 
     const std::string filename;
 
@@ -93,7 +93,7 @@ typedef CertFile PemCert;
 
 class DerCert : public CertFile {
   public:
-    DerCert(const std::string&& p_filename) : CertFile(std::move(p_filename)) {}
+    DerCert(std::string&& p_filename) : CertFile(std::move(p_filename)) {}
 
     virtual const char* GetCertType(void) const {
         return "DER";
@@ -103,7 +103,7 @@ class DerCert : public CertFile {
 // specify private keyfile for TLS and SSL client cert
 class KeyFile {
   public:
-    KeyFile(const std::string&& p_filename) : filename(std::move(p_filename)) {}
+    KeyFile(std::string&& p_filename) : filename(std::move(p_filename)) {}
 
     template <typename FileType, typename PassType>
     KeyFile(FileType&& p_filename, PassType p_password)
@@ -121,7 +121,7 @@ typedef KeyFile PemKey;
 
 class DerKey : public KeyFile {
   public:
-    DerKey(const std::string&& p_filename) : KeyFile(std::move(p_filename)) {}
+    DerKey(std::string&& p_filename) : KeyFile(std::move(p_filename)) {}
 
     template <typename FileType, typename PassType>
     DerKey(FileType&& p_filename, PassType p_password)
@@ -255,7 +255,7 @@ struct MaxTLSv1_3 {};
 // path to Certificate Authority (CA) bundle
 class CaInfo {
   public:
-    CaInfo(const std::string&& p_filename) : filename(std::move(p_filename)) {}
+    CaInfo(std::string&& p_filename) : filename(std::move(p_filename)) {}
 
     std::string filename;
 };
@@ -263,7 +263,7 @@ class CaInfo {
 // specify directory holding CA certificates
 class CaPath {
   public:
-    CaPath(const std::string&& p_filename) : filename(std::move(p_filename)) {}
+    CaPath(std::string&& p_filename) : filename(std::move(p_filename)) {}
 
     std::string filename;
 };
@@ -271,7 +271,7 @@ class CaPath {
 // specify a Certificate Revocation List file
 class Crl {
   public:
-    Crl(const std::string&& p_filename) : filename(std::move(p_filename)) {}
+    Crl(std::string&& p_filename) : filename(std::move(p_filename)) {}
 
     std::string filename;
 };

--- a/include/cpr/unix_socket.h
+++ b/include/cpr/unix_socket.h
@@ -7,7 +7,7 @@ namespace cpr {
 
 class UnixSocket {
   public:
-    UnixSocket(const std::string&& unix_socket) : unix_socket_(std::move(unix_socket)) {}
+    UnixSocket(std::string&& unix_socket) : unix_socket_(std::move(unix_socket)) {}
 
     const char* GetUnixSocketString() const noexcept;
 

--- a/include/cpr/user_agent.h
+++ b/include/cpr/user_agent.h
@@ -11,7 +11,7 @@ class UserAgent : public StringHolder<UserAgent> {
   public:
     UserAgent() : StringHolder<UserAgent>() {}
     UserAgent(const std::string& useragent) : StringHolder<UserAgent>(useragent) {}
-    UserAgent(const std::string&& useragent)
+    UserAgent(std::string&& useragent)
             : StringHolder<UserAgent>(std::move(useragent)) {}
     UserAgent(const char* useragent) : StringHolder<UserAgent>(useragent) {}
     UserAgent(const char* str, size_t len) : StringHolder<UserAgent>(str, len) {}

--- a/test/httpsServer.cpp
+++ b/test/httpsServer.cpp
@@ -1,8 +1,8 @@
 #include "httpsServer.hpp"
 
 namespace cpr {
-HttpsServer::HttpsServer(const std::string&& baseDirPath, const std::string&& sslCertFileName,
-                         const std::string&& sslKeyFileName)
+HttpsServer::HttpsServer(std::string&& baseDirPath, std::string&& sslCertFileName,
+                         std::string&& sslKeyFileName)
         : baseDirPath(std::move(baseDirPath)), sslCertFileName(std::move(sslCertFileName)),
           sslKeyFileName(std::move(sslKeyFileName)) {}
 

--- a/test/httpsServer.hpp
+++ b/test/httpsServer.hpp
@@ -16,8 +16,8 @@ class HttpsServer : public AbstractServer {
     const std::string sslKeyFileName;
 
   public:
-    explicit HttpsServer(const std::string&& baseDirPath, const std::string&& sslCertFileName,
-                         const std::string&& sslKeyFileName);
+    explicit HttpsServer(std::string&& baseDirPath, std::string&& sslCertFileName,
+                         std::string&& sslKeyFileName);
     ~HttpsServer() = default;
 
     std::string GetBaseUrl() override;

--- a/test/post_tests.cpp
+++ b/test/post_tests.cpp
@@ -182,6 +182,20 @@ TEST(UrlEncodedPostTests, FormPostFileNoCopyTest) {
     EXPECT_EQ(ErrorCode::OK, response.error.code);
 }
 
+TEST(UrlEncodedPostTests, TimeoutPostTest) {
+    Url url{server->GetBaseUrl() + "/json_post.html"};
+    std::string body{"{\"RegisterObject\": {\"DeviceID\": \"65010000005030000001\"}}"};
+    cpr::Response response =
+            cpr::Post(url, cpr::Header{{"Content-Type", "application/json"}}, cpr::Body{body},
+                      cpr::ConnectTimeout{3000}, cpr::Timeout{3000});
+    std::string expected_text{"{\"RegisterObject\": {\"DeviceID\": \"65010000005030000001\"}}"};
+    EXPECT_EQ(expected_text, response.text);
+    EXPECT_EQ(url, response.url);
+    EXPECT_EQ(std::string{"application/json"}, response.header["content-type"]);
+    EXPECT_EQ(201, response.status_code);
+    EXPECT_EQ(ErrorCode::OK, response.error.code);
+}
+
 TEST(UrlEncodedPostTests, FormPostFileBufferTest) {
     auto content = std::string{"hello world"};
     auto url = Url{server->GetBaseUrl() + "/form_post.html"};


### PR DESCRIPTION
Add an options to get the response data as bytes and not as text decoded.
Here is an example from a python code that uses Pycurl

Actually its a library i wrote my self called besocurl

You can see the code here: https://github.com/OmriBaso/besoCurl
If you dont want to go into my repo and see the code he is a demonstartion 
![image](https://user-images.githubusercontent.com/50461376/104108029-ed6a4180-52c9-11eb-8c1e-cbc0e147eba1.png)
