### PR TITLE
Fix segfaults in tests (#495)

### DIFF
--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -1,5 +1,6 @@
 #include "httpServer.hpp"
 #include <string>
+#include <system_error>
 
 namespace cpr {
 std::string HttpServer::GetBaseUrl() {
@@ -16,6 +17,9 @@ mg_connection* HttpServer::initServer(mg_mgr* mgr,
     mg_mgr_init(mgr, this);
     std::string port = std::to_string(GetPort());
     mg_connection* c = mg_bind(mgr, port.c_str(), event_handler);
+    if (!c) {
+        throw std::system_error(errno, std::system_category(), "Failed to bind to port " + port);
+    }
     mg_set_protocol_http_websocket(c);
     return c;
 }

--- a/test/httpServer.cpp
+++ b/test/httpServer.cpp
@@ -8,7 +8,8 @@ std::string HttpServer::GetBaseUrl() {
 }
 
 uint16_t HttpServer::GetPort() {
-    return 8080;
+    // Unassigned port number in the ephemeral range
+    return 61936;
 }
 
 mg_connection* HttpServer::initServer(mg_mgr* mgr,

--- a/test/httpsServer.cpp
+++ b/test/httpsServer.cpp
@@ -12,7 +12,8 @@ std::string HttpsServer::GetBaseUrl() {
 }
 
 uint16_t HttpsServer::GetPort() {
-    return 8081;
+    // Unassigned port in the ephemeral range
+    return 61937;
 }
 
 mg_connection* HttpsServer::initServer(mg_mgr* mgr,

--- a/test/httpsServer.cpp
+++ b/test/httpsServer.cpp
@@ -1,4 +1,5 @@
 #include "httpsServer.hpp"
+#include <system_error>
 
 namespace cpr {
 HttpsServer::HttpsServer(std::string&& baseDirPath, std::string&& sslCertFileName,
@@ -24,6 +25,9 @@ mg_connection* HttpsServer::initServer(mg_mgr* mgr,
     bind_opts.ssl_key = sslKeyFileName.c_str();
     std::string port = std::to_string(GetPort());
     mg_connection* c = mg_bind_opt(mgr, port.c_str(), event_handler, bind_opts);
+    if (!c) {
+        throw std::system_error(errno, std::system_category(), "Failed to bind to port " + port);
+    }
     mg_set_protocol_http_websocket(c);
     return c;
 }


### PR DESCRIPTION
When the port in `GetPort()` is already in use, `mg_bind` returns `null`,
leading to a segfault in `mg_set_protocol_http_websocket`. This PR
causes an easily readable error when this occurs. Since this is caused
by a library function, `errno` is used to get the precise error.

This PR also changes the ports used in the test suite to be in the
ephemeral range, making it much less likely that a collision occurs.

Closes: #495