### PR TITLE
Make Session objets movable for users

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -701,7 +701,9 @@ Response Session::Impl::Complete(CURLcode curl_error)
 
 // clang-format off
 Session::Session() : pimpl_(new Impl()) {}
+Session::Session(Session&& old) noexcept = default;
 Session::~Session() = default;
+Session& Session::operator=(Session&& old) noexcept = default;
 void Session::SetReadCallback(const ReadCallback& read) { pimpl_->SetReadCallback(read); }
 void Session::SetHeaderCallback(const HeaderCallback& header) { pimpl_->SetHeaderCallback(header); }
 void Session::SetWriteCallback(const WriteCallback& write) { pimpl_->SetWriteCallback(write); }

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -34,12 +34,12 @@ namespace cpr {
 class Session {
   public:
     Session();
-    Session(Session&& old) noexcept = default;
+    Session(Session&& old) noexcept;
     Session(const Session& other) = delete;
 
     ~Session();
 
-    Session& operator=(Session&& old) noexcept = default;
+    Session& operator=(Session&& old) noexcept;
     Session& operator=(const Session& other) = delete;
 
     void SetUrl(const Url& url);


### PR DESCRIPTION
Session's move constructor and move assignment operator were not usable from the public API because they were defined inline in the header. This was causing an "use of undefined type Impl" from unique_ptr.