### PR TITLE
support a  general SetOption API :  SetOption(int option, void* value)

### DIFF
--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -113,6 +113,7 @@ class Session {
     void SetOption(const Verbose& verbose);
     void SetOption(const UnixSocket& unix_socket);
     void SetOption(const SslOptions& options);
+    int SetOption(int option, void* value);
 
     Response Delete();
     Response Download(const WriteCallback& write);


### PR DESCRIPTION
Some times，we must set some rare curl options ， like：

```
CURLOPT_OPENSOCKETFUNCTION
CURLOPT_SOCKOPTFUNCTION 
CURLOPT_DNS_CACHE_TIMEOUT
```

it would be nice to have a general API to do such things.
