### PR TITLE
Fixed session copy/move bug i.e added desctructor in Session::Impl class

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -24,6 +24,7 @@ constexpr long OFF = 0L;
 class Session::Impl {
   public:
     Impl();
+    ~Impl();
 
     void SetUrl(const Url& url);
     void SetParameters(const Parameters& parameters);
@@ -135,6 +136,7 @@ Session::Impl::Impl() : curl_(new CurlHolder()) {
 #endif
 #endif
 }
+Session::Impl::~Impl() {}
 
 void Session::Impl::SetUrl(const Url& url) {
     url_ = url;


### PR DESCRIPTION
issue [553](https://github.com/whoshuu/cpr/issues/553) fixed.