### PR TITLE
Change test behaviour for better supporting FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ else()
     # We only need HTTP (and HTTPS) support:
     set(HTTP_ONLY ON CACHE INTERNAL "" FORCE)
     set(BUILD_CURL_EXE OFF CACHE INTERNAL "" FORCE)
-    set(BUILD_TESTING OFF CACHE INTERNAL "" FORCE)
+    set(BUILD_TESTING OFF)
 
     if (CPR_ENABLE_SSL)
         set(SSL_ENABLED ON CACHE INTERNAL "" FORCE)
@@ -269,7 +269,7 @@ endif()
 add_subdirectory(cpr)
 add_subdirectory(include)
 
-if(CPR_BUILD_TESTS)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND CPR_BUILD_TESTS)
     enable_testing()
     add_subdirectory(test)
 endif()


### PR DESCRIPTION
As discussed the changes for BUILD_TESTING. Furthermore I also added a clause for automatically disabling tests, when the library is not the root project (so is included in another project). 

Some general note. I think you should work on your CMake File a little bit. It seems like it has grown quite a bit and seems a little bit messy. Here are a few tips: 

* Put CMake function / macro in their own file in the cmake folder (for instance cpr_option)
* Divide your file in a few sections with comments, for instance Project Wide Setup and Dependencies
* Use include_subdirectory more heavily. For instance I use a seperate dependency folder for all my FetchContent stuff. Furthermore it's quite convenient to have one folder for each dependency as you can set Variables without affecting your scope (So you could set BUILD_TESTING to false for curl, but set it to true for your own tests) 
* FetchContent provides options for specifingy releases / tags, just use that instead of the full url and hash
* Repeat if statements if this allows you to split the cmake code up more logically. For example you don't need to fetch GTest in your test folder or in the if statement at the bottom. You can still fetch it in the dependencies folder, but just repeat the if clause there 
* Avoid force overwriting cache variable 

Just a few quick things I noticed. 

You might wanna have a look here for inspiration https://github.com/rbock/sqlpp17. I did the cmake code there. Not garantuees sthat it's perfect, but I find it quite readable. 

