### PR TITLE
Fix shadowed variable warnings

### DIFF
--- a/cpr/multipart.cpp
+++ b/cpr/multipart.cpp
@@ -1,5 +1,5 @@
 #include "cpr/multipart.h"
 
 namespace cpr {
-Multipart::Multipart(const std::initializer_list<Part>& parts) : parts{parts} {}
+Multipart::Multipart(const std::initializer_list<Part>& p_parts) : parts{p_parts} {}
 } // namespace cpr

--- a/include/cpr/api.h
+++ b/include/cpr/api.h
@@ -44,7 +44,7 @@ Response Get(Ts&&... ts) {
 template <typename... Ts>
 AsyncResponse GetAsync(Ts... ts) {
     return std::async(
-            std::launch::async, [](Ts... ts) { return Get(std::move(ts)...); }, std::move(ts)...);
+            std::launch::async, [](Ts... ts_inner) { return Get(std::move(ts_inner)...); }, std::move(ts)...);
 }
 
 // Get callback methods
@@ -52,7 +52,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto GetCallback(Then then, Ts... ts) -> std::future<decltype(then(Get(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then, Ts... ts) { return then(Get(std::move(ts)...)); },
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Get(std::move(ts_inner)...)); },
             std::move(then), std::move(ts)...);
 }
 
@@ -68,7 +68,7 @@ Response Post(Ts&&... ts) {
 template <typename... Ts>
 AsyncResponse PostAsync(Ts... ts) {
     return std::async(
-            std::launch::async, [](Ts... ts) { return Post(std::move(ts)...); }, std::move(ts)...);
+            std::launch::async, [](Ts... ts_inner) { return Post(std::move(ts_inner)...); }, std::move(ts)...);
 }
 
 // Post callback methods
@@ -76,7 +76,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto PostCallback(Then then, Ts... ts) -> std::future<decltype(then(Post(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then, Ts... ts) { return then(Post(std::move(ts)...)); },
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Post(std::move(ts_inner)...)); },
             std::move(then), std::move(ts)...);
 }
 
@@ -92,7 +92,7 @@ Response Put(Ts&&... ts) {
 template <typename... Ts>
 AsyncResponse PutAsync(Ts... ts) {
     return std::async(
-            std::launch::async, [](Ts... ts) { return Put(std::move(ts)...); }, std::move(ts)...);
+            std::launch::async, [](Ts... ts_inner) { return Put(std::move(ts_inner)...); }, std::move(ts)...);
 }
 
 // Put callback methods
@@ -100,7 +100,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto PutCallback(Then then, Ts... ts) -> std::future<decltype(then(Put(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then, Ts... ts) { return then(Put(std::move(ts)...)); },
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Put(std::move(ts_inner)...)); },
             std::move(then), std::move(ts)...);
 }
 
@@ -116,7 +116,7 @@ Response Head(Ts&&... ts) {
 template <typename... Ts>
 AsyncResponse HeadAsync(Ts... ts) {
     return std::async(
-            std::launch::async, [](Ts... ts) { return Head(std::move(ts)...); }, std::move(ts)...);
+            std::launch::async, [](Ts... ts_inner) { return Head(std::move(ts_inner)...); }, std::move(ts)...);
 }
 
 // Head callback methods
@@ -124,7 +124,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto HeadCallback(Then then, Ts... ts) -> std::future<decltype(then(Head(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then, Ts... ts) { return then(Head(std::move(ts)...)); },
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Head(std::move(ts_inner)...)); },
             std::move(then), std::move(ts)...);
 }
 
@@ -140,7 +140,7 @@ Response Delete(Ts&&... ts) {
 template <typename... Ts>
 AsyncResponse DeleteAsync(Ts... ts) {
     return std::async(
-            std::launch::async, [](Ts... ts) { return Delete(std::move(ts)...); },
+            std::launch::async, [](Ts... ts_inner) { return Delete(std::move(ts_inner)...); },
             std::move(ts)...);
 }
 
@@ -149,7 +149,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto DeleteCallback(Then then, Ts... ts) -> std::future<decltype(then(Delete(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then, Ts... ts) { return then(Delete(std::move(ts)...)); },
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Delete(std::move(ts_inner)...)); },
             std::move(then), std::move(ts)...);
 }
 
@@ -165,7 +165,7 @@ Response Options(Ts&&... ts) {
 template <typename... Ts>
 AsyncResponse OptionsAsync(Ts... ts) {
     return std::async(
-            std::launch::async, [](Ts... ts) { return Options(std::move(ts)...); },
+            std::launch::async, [](Ts... ts_inner) { return Options(std::move(ts_inner)...); },
             std::move(ts)...);
 }
 
@@ -175,7 +175,7 @@ template <typename Then, typename... Ts>
 auto OptionsCallback(Then then, Ts... ts)
         -> std::future<decltype(then(Options(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then, Ts... ts) { return then(Options(std::move(ts)...)); },
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Options(std::move(ts_inner)...)); },
             std::move(then), std::move(ts)...);
 }
 
@@ -191,7 +191,7 @@ Response Patch(Ts&&... ts) {
 template <typename... Ts>
 AsyncResponse PatchAsync(Ts... ts) {
     return std::async(
-            std::launch::async, [](Ts... ts) { return Patch(std::move(ts)...); }, std::move(ts)...);
+            std::launch::async, [](Ts... ts_inner) { return Patch(std::move(ts_inner)...); }, std::move(ts)...);
 }
 
 // Patch callback methods
@@ -199,7 +199,7 @@ template <typename Then, typename... Ts>
 // NOLINTNEXTLINE(fuchsia-trailing-return)
 auto PatchCallback(Then then, Ts... ts) -> std::future<decltype(then(Patch(std::move(ts)...)))> {
     return std::async(
-            std::launch::async, [](Then then, Ts... ts) { return then(Patch(std::move(ts)...)); },
+            std::launch::async, [](Then then_inner, Ts... ts_inner) { return then_inner(Patch(std::move(ts_inner)...)); },
             std::move(then), std::move(ts)...);
 }
 

--- a/include/cpr/callback.h
+++ b/include/cpr/callback.h
@@ -12,10 +12,10 @@ class ReadCallback {
   public:
     ReadCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    ReadCallback(std::function<bool(char* buffer, size_t& size)> callback)
-            : size{-1}, callback{std::move(callback)} {}
-    ReadCallback(cpr_off_t size, std::function<bool(char* buffer, size_t& size)> callback)
-            : size{size}, callback{std::move(callback)} {}
+    ReadCallback(std::function<bool(char* buffer, size_t& size)> p_callback)
+            : size{-1}, callback{std::move(p_callback)} {}
+    ReadCallback(cpr_off_t p_size, std::function<bool(char* buffer, size_t& size)> p_callback)
+            : size{p_size}, callback{std::move(p_callback)} {}
 
     cpr_off_t size{};
     std::function<bool(char* buffer, size_t& size)> callback;
@@ -25,8 +25,8 @@ class HeaderCallback {
   public:
     HeaderCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    HeaderCallback(std::function<bool(std::string header)> callback)
-            : callback(std::move(callback)) {}
+    HeaderCallback(std::function<bool(std::string header)> p_callback)
+            : callback(std::move(p_callback)) {}
 
     std::function<bool(std::string header)> callback;
 };
@@ -35,7 +35,7 @@ class WriteCallback {
   public:
     WriteCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    WriteCallback(std::function<bool(std::string data)> callback) : callback(std::move(callback)) {}
+    WriteCallback(std::function<bool(std::string data)> p_callback) : callback(std::move(p_callback)) {}
 
     std::function<bool(std::string data)> callback;
 };
@@ -46,8 +46,8 @@ class ProgressCallback {
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
     ProgressCallback(std::function<bool(size_t downloadTotal, size_t downloadNow,
                                         size_t uploadTotal, size_t uploadNow)>
-                             callback)
-            : callback(std::move(callback)) {}
+                             p_callback)
+            : callback(std::move(p_callback)) {}
 
     std::function<bool(size_t downloadTotal, size_t downloadNow, size_t uploadTotal,
                        size_t uploadNow)>
@@ -67,8 +67,8 @@ class DebugCallback {
     };
     DebugCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    DebugCallback(std::function<void(InfoType type, std::string data)> callback)
-            : callback(std::move(callback)) {}
+    DebugCallback(std::function<void(InfoType type, std::string data)> p_callback)
+            : callback(std::move(p_callback)) {}
 
     std::function<void(InfoType type, std::string data)> callback;
 };

--- a/include/cpr/cookies.h
+++ b/include/cpr/cookies.h
@@ -25,13 +25,13 @@ class Cookies {
     bool encode{true};
 
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Cookies(bool encode = true) : encode(encode) {}
+    Cookies(bool p_encode = true) : encode(p_encode) {}
     Cookies(const std::initializer_list<std::pair<const std::string, std::string>>& pairs,
-            bool encode = true)
-            : encode(encode), map_{pairs} {}
+            bool p_encode = true)
+            : encode(p_encode), map_{pairs} {}
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Cookies(const std::map<std::string, std::string>& map, bool encode = true)
-            : encode(encode), map_{map} {}
+    Cookies(const std::map<std::string, std::string>& map, bool p_encode = true)
+            : encode(p_encode), map_{map} {}
 
     std::string& operator[](const std::string& key);
     std::string GetEncoded(const CurlHolder& holder) const;

--- a/include/cpr/curl_container.h
+++ b/include/cpr/curl_container.h
@@ -12,9 +12,9 @@
 namespace cpr {
 
 struct Parameter {
-    Parameter(const std::string& key, const std::string& value) : key{key}, value{value} {}
-    Parameter(std::string&& key, std::string&& value)
-            : key{std::move(key)}, value{std::move(value)} {}
+    Parameter(const std::string& p_key, const std::string& p_value) : key{p_key}, value{p_value} {}
+    Parameter(std::string&& p_key, std::string&& p_value)
+            : key{std::move(p_key)}, value{std::move(p_value)} {}
 
     std::string key;
     std::string value;

--- a/include/cpr/limit_rate.h
+++ b/include/cpr/limit_rate.h
@@ -7,8 +7,8 @@ namespace cpr {
 
 class LimitRate {
   public:
-    LimitRate(const std::int64_t downrate, const std::int64_t uprate)
-            : downrate(downrate), uprate(uprate) {}
+    LimitRate(const std::int64_t p_downrate, const std::int64_t p_uprate)
+            : downrate(p_downrate), uprate(p_uprate) {}
 
     std::int64_t downrate = 0;
     std::int64_t uprate = 0;

--- a/include/cpr/low_speed.h
+++ b/include/cpr/low_speed.h
@@ -7,7 +7,7 @@ namespace cpr {
 
 class LowSpeed {
   public:
-    LowSpeed(const std::int32_t limit, const std::int32_t time) : limit(limit), time(time) {}
+    LowSpeed(const std::int32_t p_limit, const std::int32_t p_time) : limit(p_limit), time(p_time) {}
 
     std::int32_t limit;
     std::int32_t time;

--- a/include/cpr/max_redirects.h
+++ b/include/cpr/max_redirects.h
@@ -7,8 +7,8 @@ namespace cpr {
 
 class MaxRedirects {
   public:
-    explicit MaxRedirects(const std::int32_t number_of_redirects)
-            : number_of_redirects(number_of_redirects) {}
+    explicit MaxRedirects(const std::int32_t p_number_of_redirects)
+            : number_of_redirects(p_number_of_redirects) {}
 
     std::int32_t number_of_redirects;
 };

--- a/include/cpr/multipart.h
+++ b/include/cpr/multipart.h
@@ -10,8 +10,8 @@
 namespace cpr {
 
 struct File {
-    explicit File(std::string&& filepath) : filepath(std::move(filepath)) {}
-    explicit File(const std::string& filepath) : filepath(filepath) {}
+    explicit File(std::string&& p_filepath) : filepath(std::move(p_filepath)) {}
+    explicit File(const std::string& p_filepath) : filepath(p_filepath) {}
     const std::string filepath;
 };
 
@@ -19,13 +19,13 @@ struct Buffer {
     using data_t = const unsigned char*;
 
     template <typename Iterator>
-    Buffer(Iterator begin, Iterator end, std::string&& filename)
+    Buffer(Iterator begin, Iterator end, std::string&& p_filename)
             // Ignored here since libcurl reqires a long.
             // There is also no way around the reinterpret_cast.
             // NOLINTNEXTLINE(google-runtime-int, cppcoreguidelines-pro-type-reinterpret-cast)
             : data{reinterpret_cast<data_t>(&(*begin))}, datalen{static_cast<long>(
                                                             std::distance(begin, end))},
-              filename(std::move(filename)) {
+              filename(std::move(p_filename)) {
         is_random_access_iterator(begin, end);
         static_assert(sizeof(*begin) == 1, "only byte buffers can be used");
     }
@@ -43,17 +43,17 @@ struct Buffer {
 };
 
 struct Part {
-    Part(const std::string& name, const std::string& value, const std::string& content_type = {})
-            : name{name}, value{value},
-              content_type{content_type}, is_file{false}, is_buffer{false} {}
-    Part(const std::string& name, const std::int32_t& value, const std::string& content_type = {})
-            : name{name}, value{std::to_string(value)},
-              content_type{content_type}, is_file{false}, is_buffer{false} {}
-    Part(const std::string& name, const File& file, const std::string& content_type = {})
-            : name{name}, value{file.filepath},
-              content_type{content_type}, is_file{true}, is_buffer{false} {}
-    Part(const std::string& name, const Buffer& buffer, const std::string& content_type = {})
-            : name{name}, value{buffer.filename}, content_type{content_type}, data{buffer.data},
+    Part(const std::string& p_name, const std::string& p_value, const std::string& p_content_type = {})
+            : name{p_name}, value{p_value},
+              content_type{p_content_type}, is_file{false}, is_buffer{false} {}
+    Part(const std::string& p_name, const std::int32_t& p_value, const std::string& p_content_type = {})
+            : name{p_name}, value{std::to_string(p_value)},
+              content_type{p_content_type}, is_file{false}, is_buffer{false} {}
+    Part(const std::string& p_name, const File& file, const std::string& p_content_type = {})
+            : name{p_name}, value{file.filepath},
+              content_type{p_content_type}, is_file{true}, is_buffer{false} {}
+    Part(const std::string& p_name, const Buffer& buffer, const std::string& p_content_type = {})
+            : name{p_name}, value{buffer.filename}, content_type{p_content_type}, data{buffer.data},
               datalen{buffer.datalen}, is_file{false}, is_buffer{true} {}
 
     std::string name;

--- a/include/cpr/ssl_options.h
+++ b/include/cpr/ssl_options.h
@@ -70,7 +70,7 @@ class VerifySsl {
   public:
     VerifySsl() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    VerifySsl(bool verify) : verify(verify) {}
+    VerifySsl(bool p_verify) : verify(p_verify) {}
 
     explicit operator bool() const {
         return verify;
@@ -147,7 +147,7 @@ class ALPN {
   public:
     ALPN() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    ALPN(bool enabled) : enabled(enabled) {}
+    ALPN(bool p_enabled) : enabled(p_enabled) {}
 
     explicit operator bool() const {
         return enabled;
@@ -164,7 +164,7 @@ class NPN {
   public:
     NPN() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    NPN(bool enabled) : enabled(enabled) {}
+    NPN(bool p_enabled) : enabled(p_enabled) {}
 
     explicit operator bool() const {
         return enabled;
@@ -180,7 +180,7 @@ class VerifyHost {
   public:
     VerifyHost() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    VerifyHost(bool enabled) : enabled(enabled) {}
+    VerifyHost(bool p_enabled) : enabled(p_enabled) {}
 
     explicit operator bool() const {
         return enabled;
@@ -194,7 +194,7 @@ class VerifyPeer {
   public:
     VerifyPeer() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    VerifyPeer(bool enabled) : enabled(enabled) {}
+    VerifyPeer(bool p_enabled) : enabled(p_enabled) {}
 
     explicit operator bool() const {
         return enabled;
@@ -208,7 +208,7 @@ class VerifyPeer {
 class VerifyStatus {
   public:
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    VerifyStatus(bool enabled) : enabled(enabled) {}
+    VerifyStatus(bool p_enabled) : enabled(p_enabled) {}
 
     explicit operator bool() const {
         return enabled;
@@ -318,7 +318,7 @@ class SessionIdCache {
   public:
     SessionIdCache() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    SessionIdCache(bool enabled) : enabled(enabled) {}
+    SessionIdCache(bool p_enabled) : enabled(p_enabled) {}
 
     explicit operator bool() const {
         return enabled;
@@ -333,7 +333,7 @@ class SslFastStart {
   public:
     SslFastStart() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    SslFastStart(bool enabled) : enabled(enabled) {}
+    SslFastStart(bool p_enabled) : enabled(p_enabled) {}
 
     explicit operator bool() const {
         return enabled;
@@ -347,7 +347,7 @@ class NoRevoke {
 public:
     NoRevoke() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    NoRevoke(bool enabled) : enabled(enabled) {}
+    NoRevoke(bool p_enabled) : enabled(p_enabled) {}
 
     explicit operator bool() const {
         return enabled;

--- a/include/cpr/verbose.h
+++ b/include/cpr/verbose.h
@@ -7,7 +7,7 @@ class Verbose {
   public:
     Verbose() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    Verbose(const bool verbose) : verbose{verbose} {}
+    Verbose(const bool p_verbose) : verbose{p_verbose} {}
 
     bool verbose = true;
 };


### PR DESCRIPTION
I've tried to follow the existing naming convention already used by some files where some instances of this problem have been fixed previously.