### PR TITLE
Don't forcibly override user setting for FETCHCONTENT_QUIET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,8 +184,6 @@ else()
         set(CMAKE_USE_SECTRANSP ON CACHE INTERNAL "" FORCE)
     endif()
 
-    # Show progress of FetchContent:
-    set(FETCHCONTENT_QUIET OFF CACHE INTERNAL "" FORCE)
     FetchContent_Declare(curl
                          URL                    https://github.com/curl/curl/releases/download/curl-7_75_0/curl-7.75.0.tar.xz
                          URL_HASH               SHA256=fe0c49d8468249000bda75bcfdf9e30ff7e9a86d35f1a21f428d79c389d55675 # the file hash for curl-7.75.0.tar.xz

--- a/cmake/zlib_external.cmake
+++ b/cmake/zlib_external.cmake
@@ -8,7 +8,6 @@ endif()
 set(ZLIB_COMPAT ON CACHE INTERNAL "" FORCE)
 set(ZLIB_ENABLE_TESTS OFF CACHE INTERNAL "" FORCE)
 
-set(FETCHCONTENT_QUIET OFF CACHE INTERNAL "" FORCE)
 FetchContent_Declare(zlib
                     GIT_REPOSITORY https://github.com/zlib-ng/zlib-ng
                     GIT_TAG v2.0.0-RC2


### PR DESCRIPTION
By forcing FETCHCONTENT_QUIET to be OFF, it means any project that
consumes cpr will end up with all of its dependencies having non-quiet
output. This variable is meant to be a user control, projects should not
set it.

Fixes: #567