### PR TITLE
add interface GetDownloadFileLength

### DIFF
--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -66,7 +66,7 @@ class Session::Impl {
     void SetVerbose(const Verbose& verbose);
     void SetSslOptions(const SslOptions& options);
 
-    int64_t GetDownloadFileLength();
+    cpr_off_t GetDownloadFileLength();
     Response Delete();
     Response Download(const WriteCallback& write);
     Response Download(std::ofstream& file);
@@ -233,16 +233,14 @@ void Session::Impl::SetUserAgent(const UserAgent& ua) {
 void Session::Impl::SetPayload(Payload&& payload) {
     hasBodyOrPayload_ = true;
     const std::string content = payload.GetContent(*curl_);
-    curl_easy_setopt(curl_->handle, CURLOPT_POSTFIELDSIZE_LARGE,
-                     static_cast<curl_off_t>(content.length()));
+    curl_easy_setopt(curl_->handle, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(content.length()));
     curl_easy_setopt(curl_->handle, CURLOPT_COPYPOSTFIELDS, content.c_str());
 }
 
 void Session::Impl::SetPayload(const Payload& payload) {
     hasBodyOrPayload_ = true;
     const std::string content = payload.GetContent(*curl_);
-    curl_easy_setopt(curl_->handle, CURLOPT_POSTFIELDSIZE_LARGE,
-                     static_cast<curl_off_t>(content.length()));
+    curl_easy_setopt(curl_->handle, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(content.length()));
     curl_easy_setopt(curl_->handle, CURLOPT_COPYPOSTFIELDS, content.c_str());
 }
 
@@ -270,9 +268,7 @@ void Session::Impl::SetMultipart(Multipart&& multipart) {
         std::vector<curl_forms> formdata;
         if (part.is_buffer) {
             // Do not use formdata, to prevent having to use reinterpreter_cast:
-            curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, part.name.c_str(), CURLFORM_BUFFER,
-                         part.value.c_str(), CURLFORM_BUFFERPTR, part.data, CURLFORM_BUFFERLENGTH,
-                         part.datalen, CURLFORM_END);
+            curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, part.name.c_str(), CURLFORM_BUFFER, part.value.c_str(), CURLFORM_BUFFERPTR, part.data, CURLFORM_BUFFERLENGTH, part.datalen, CURLFORM_END);
         } else {
             formdata.push_back({CURLFORM_COPYNAME, part.name.c_str()});
             if (part.is_file) {
@@ -303,9 +299,7 @@ void Session::Impl::SetMultipart(const Multipart& multipart) {
         std::vector<curl_forms> formdata;
         if (part.is_buffer) {
             // Do not use formdata, to prevent having to use reinterpreter_cast:
-            curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, part.name.c_str(), CURLFORM_BUFFER,
-                         part.value.c_str(), CURLFORM_BUFFERPTR, part.data, CURLFORM_BUFFERLENGTH,
-                         part.datalen, CURLFORM_END);
+            curl_formadd(&formpost, &lastptr, CURLFORM_COPYNAME, part.name.c_str(), CURLFORM_BUFFER, part.value.c_str(), CURLFORM_BUFFERPTR, part.data, CURLFORM_BUFFERLENGTH, part.datalen, CURLFORM_END);
         } else {
             formdata.push_back({CURLFORM_COPYNAME, part.name.c_str()});
             if (part.is_file) {
@@ -354,15 +348,13 @@ void Session::Impl::SetCookies(const Cookies& cookies) {
 
 void Session::Impl::SetBody(Body&& body) {
     hasBodyOrPayload_ = true;
-    curl_easy_setopt(curl_->handle, CURLOPT_POSTFIELDSIZE_LARGE,
-                     static_cast<curl_off_t>(body.str().length()));
+    curl_easy_setopt(curl_->handle, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.str().length()));
     curl_easy_setopt(curl_->handle, CURLOPT_COPYPOSTFIELDS, body.c_str());
 }
 
 void Session::Impl::SetBody(const Body& body) {
     hasBodyOrPayload_ = true;
-    curl_easy_setopt(curl_->handle, CURLOPT_POSTFIELDSIZE_LARGE,
-                     static_cast<curl_off_t>(body.str().length()));
+    curl_easy_setopt(curl_->handle, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.str().length()));
     curl_easy_setopt(curl_->handle, CURLOPT_POSTFIELDS, body.c_str());
 }
 
@@ -482,8 +474,7 @@ void Session::Impl::SetSslOptions(const SslOptions& options) {
     }
 #endif
 #if SUPPORT_SESSIONID_CACHE
-    curl_easy_setopt(curl_->handle, CURLOPT_SSL_SESSIONID_CACHE,
-                     options.session_id_cache ? ON : OFF);
+    curl_easy_setopt(curl_->handle, CURLOPT_SSL_SESSIONID_CACHE, options.session_id_cache ? ON : OFF);
 #endif
 }
 
@@ -494,9 +485,9 @@ void Session::Impl::PrepareDelete() {
     prepareCommon();
 }
 
-int64_t Session::Impl::GetDownloadFileLength() {
-	curl_off_t downloadFileLenth = -1;
-	curl_easy_setopt(curl_->handle, CURLOPT_URL, url_.c_str());
+cpr_off_t Session::Impl::GetDownloadFileLength() {
+    cpr_off_t downloadFileLenth = -1;
+    curl_easy_setopt(curl_->handle, CURLOPT_URL, url_.c_str());
 
     std::string protocol = url_.str().substr(0, url_.str().find(':'));
     if (proxies_.has(protocol)) {
@@ -511,11 +502,10 @@ int64_t Session::Impl::GetDownloadFileLength() {
 
     curl_easy_setopt(curl_->handle, CURLOPT_HTTPGET, 1);
     curl_easy_setopt(curl_->handle, CURLOPT_NOBODY, 1);
-    if (curl_easy_perform(curl_->handle) == CURLE_OK)
-    {
-       curl_easy_getinfo(curl_->handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &downloadFileLenth);
+    if (curl_easy_perform(curl_->handle) == CURLE_OK) {
+        curl_easy_getinfo(curl_->handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &downloadFileLenth);
     }
-	return downloadFileLenth;
+    return downloadFileLenth;
 }
 
 Response Session::Impl::Delete() {
@@ -552,7 +542,7 @@ void Session::Impl::PrepareGet() {
         curl_easy_setopt(curl_->handle, CURLOPT_CUSTOMREQUEST, nullptr);
         curl_easy_setopt(curl_->handle, CURLOPT_HTTPGET, 1L);
     }
-	prepareCommon();
+    prepareCommon();
 }
 
 Response Session::Impl::Get() {
@@ -563,7 +553,7 @@ Response Session::Impl::Get() {
 void Session::Impl::PrepareHead() {
     curl_easy_setopt(curl_->handle, CURLOPT_NOBODY, 1L);
     curl_easy_setopt(curl_->handle, CURLOPT_CUSTOMREQUEST, nullptr);
-	 prepareCommon();
+    prepareCommon();
 }
 
 Response Session::Impl::Head() {
@@ -614,7 +604,7 @@ Response Session::Impl::Post() {
 void Session::Impl::PreparePut() {
     curl_easy_setopt(curl_->handle, CURLOPT_NOBODY, 0L);
     curl_easy_setopt(curl_->handle, CURLOPT_CUSTOMREQUEST, "PUT");
-	prepareCommon();
+    prepareCommon();
 }
 
 Response Session::Impl::Put() {
@@ -666,8 +656,7 @@ Response Session::Impl::makeDownloadRequest() {
     curl_slist_free_all(raw_cookies);
     std::string errorMsg = curl_->error.data();
 
-    return Response(curl_, "", std::move(header_string), std::move(cookies),
-                    Error(curl_error, std::move(errorMsg)));
+    return Response(curl_, "", std::move(header_string), std::move(cookies), Error(curl_error, std::move(errorMsg)));
 }
 
 void Session::Impl::prepareCommon() {
@@ -727,14 +716,12 @@ void Session::Impl::prepareCommon() {
     curl_easy_setopt(curl_->handle, CURLOPT_CERTINFO, 1L);
 }
 
-Response Session::Impl::makeRequest()
-{
+Response Session::Impl::makeRequest() {
     CURLcode curl_error = curl_easy_perform(curl_->handle);
     return Complete(curl_error);
 }
 
-Response Session::Impl::Complete(CURLcode curl_error)
-{
+Response Session::Impl::Complete(CURLcode curl_error) {
     curl_slist* raw_cookies{nullptr};
     curl_easy_getinfo(curl_->handle, CURLINFO_COOKIELIST, &raw_cookies);
     Cookies cookies = util::parseCookies(raw_cookies);
@@ -744,8 +731,7 @@ Response Session::Impl::Complete(CURLcode curl_error)
     hasBodyOrPayload_ = false;
 
     std::string errorMsg = curl_->error.data();
-    return Response(curl_, std::move(response_string_), std::move(header_string_), std::move(cookies),
-                    Error(curl_error, std::move(errorMsg)));
+    return Response(curl_, std::move(response_string_), std::move(header_string_), std::move(cookies), Error(curl_error, std::move(errorMsg)));
 }
 
 // clang-format off
@@ -827,7 +813,7 @@ void Session::SetOption(const Verbose& verbose) { pimpl_->SetVerbose(verbose); }
 void Session::SetOption(const UnixSocket& unix_socket) { pimpl_->SetUnixSocket(unix_socket); }
 void Session::SetOption(const SslOptions& options) { pimpl_->SetSslOptions(options); }
 
-int64_t Session::GetDownloadFileLength() { return pimpl_->GetDownloadFileLength(); }
+cpr_off_t Session::GetDownloadFileLength() { return pimpl_->GetDownloadFileLength(); }
 Response Session::Delete() { return pimpl_->Delete(); }
 Response Session::Download(const WriteCallback& write) { return pimpl_->Download(write); }
 Response Session::Download(std::ofstream& file) { return pimpl_->Download(file); }

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -119,6 +119,7 @@ class Session {
     void SetOption(const UnixSocket& unix_socket);
     void SetOption(const SslOptions& options);
 
+    int64_t GetDownloadFileLength();
     Response Delete();
     Response Download(const WriteCallback& write);
     Response Download(std::ofstream& file);

--- a/include/cpr/session.h
+++ b/include/cpr/session.h
@@ -119,7 +119,7 @@ class Session {
     void SetOption(const UnixSocket& unix_socket);
     void SetOption(const SslOptions& options);
 
-    int64_t GetDownloadFileLength();
+    cpr_off_t GetDownloadFileLength();
     Response Delete();
     Response Download(const WriteCallback& write);
     Response Download(std::ofstream& file);


### PR DESCRIPTION
Some HTTP servers don't support the HEAD method to get the length of the file, so I added the GetDownloadFileLength interface to get the length of the file before the actual download starts. 

Unnecessary memory allocation can be avoided in some scenarios.

example :
``` c++
void *global_buff = nullptr;
int64_t global_down_length = 0;

bool write_data(std::string data)
{
    memcpy(global_buff + global_down_length, data.data(), data.size());
    global_down_length += data.size();
}

int main() {
    cpr::Session session;
    session.SetUrl(cpr::Url{"http://xxx/file"});
    // memory alloc
    global_buff = malloc(session.GetDownloadFileLength());
    session.Download(cpr::WriteCallback{write_data});
    // do something
    free(global_buff);
    global_buff = nullptr;
}
```