### PR TITLE
add userdata param to callback function

### DIFF
--- a/cpr/util.cpp
+++ b/cpr/util.cpp
@@ -89,12 +89,12 @@ std::vector<std::string> split(const std::string& to_split, char delimiter) {
 
 size_t readUserFunction(char* ptr, size_t size, size_t nitems, const ReadCallback* read) {
     size *= nitems;
-    return read->callback(ptr, size) ? size : CURL_READFUNC_ABORT;
+    return (*read)(ptr, size) ? size : CURL_READFUNC_ABORT;
 }
 
 size_t headerUserFunction(char* ptr, size_t size, size_t nmemb, const HeaderCallback* header) {
     size *= nmemb;
-    return header->callback({ptr, size}) ? size : 0;
+    return (*header)({ptr, size}) ? size : 0;
 }
 
 size_t writeFunction(char* ptr, size_t size, size_t nmemb, std::string* data) {
@@ -111,7 +111,7 @@ size_t writeFileFunction(char* ptr, size_t size, size_t nmemb, std::ofstream* fi
 
 size_t writeUserFunction(char* ptr, size_t size, size_t nmemb, const WriteCallback* write) {
     size *= nmemb;
-    return write->callback({ptr, size}) ? size : 0;
+    return (*write)({ptr, size}) ? size : 0;
 }
 
 #if LIBCURL_VERSION_NUM < 0x072000
@@ -121,12 +121,12 @@ int progressUserFunction(const ProgressCallback* progress, double dltotal, doubl
 int progressUserFunction(const ProgressCallback* progress, curl_off_t dltotal, curl_off_t dlnow,
                          curl_off_t ultotal, curl_off_t ulnow) {
 #endif
-    return progress->callback(dltotal, dlnow, ultotal, ulnow) ? 0 : 1;
+    return (*progress)(dltotal, dlnow, ultotal, ulnow) ? 0 : 1;
 }
 
 int debugUserFunction(CURL* /*handle*/, curl_infotype type, char* data, size_t size,
                       const DebugCallback* debug) {
-    debug->callback(DebugCallback::InfoType(type), std::string(data, size));
+    (*debug)(DebugCallback::InfoType(type), std::string(data, size));
     return 0;
 }
 

--- a/include/cpr/callback.h
+++ b/include/cpr/callback.h
@@ -12,38 +12,54 @@ class ReadCallback {
   public:
     ReadCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    ReadCallback(std::function<bool(char* buffer, size_t& size)> p_callback) : size{-1}, callback{std::move(p_callback)} {}
-    ReadCallback(cpr_off_t p_size, std::function<bool(char* buffer, size_t& size)> p_callback) : size{p_size}, callback{std::move(p_callback)} {}
+    ReadCallback(std::function<bool(char* buffer, size_t& size, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), size{-1}, callback{std::move(p_callback)} {}
+    ReadCallback(cpr_off_t p_size, std::function<bool(char* buffer, size_t& size, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), size{p_size}, callback{std::move(p_callback)} {}
+    bool operator()(char* buffer, size_t& size) const {
+        return callback(buffer, size, userdata);
+    }
 
+    intptr_t userdata;
     cpr_off_t size{};
-    std::function<bool(char* buffer, size_t& size)> callback;
+    std::function<bool(char* buffer, size_t& size, intptr_t userdata)> callback;
 };
 
 class HeaderCallback {
   public:
     HeaderCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    HeaderCallback(std::function<bool(std::string header)> p_callback) : callback(std::move(p_callback)) {}
+    HeaderCallback(std::function<bool(std::string header, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
+    bool operator()(std::string header) const {
+        return callback(std::move(header), userdata);
+    }
 
-    std::function<bool(std::string header)> callback;
+    intptr_t userdata;
+    std::function<bool(std::string header, intptr_t userdata)> callback;
 };
 
 class WriteCallback {
   public:
     WriteCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    WriteCallback(std::function<bool(std::string data)> p_callback) : callback(std::move(p_callback)) {}
+    WriteCallback(std::function<bool(std::string data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
+    bool operator()(std::string data) const {
+        return callback(std::move(data), userdata);
+    }
 
-    std::function<bool(std::string data)> callback;
+    intptr_t userdata;
+    std::function<bool(std::string data, intptr_t userdata)> callback;
 };
 
 class ProgressCallback {
   public:
     ProgressCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    ProgressCallback(std::function<bool(cpr_off_t downloadTotal, cpr_off_t downloadNow, cpr_off_t uploadTotal, cpr_off_t uploadNow)> p_callback) : callback(std::move(p_callback)) {}
+    ProgressCallback(std::function<bool(cpr_off_t downloadTotal, cpr_off_t downloadNow, cpr_off_t uploadTotal, cpr_off_t uploadNow, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
+    bool operator()(cpr_off_t downloadTotal, cpr_off_t downloadNow, cpr_off_t uploadTotal, cpr_off_t uploadNow) const {
+        return callback(downloadTotal, downloadNow, uploadTotal, uploadNow, userdata);
+    }
 
-    std::function<bool(cpr_off_t downloadTotal, cpr_off_t downloadNow, cpr_off_t uploadTotal, cpr_off_t uploadNow)> callback;
+    intptr_t userdata;
+    std::function<bool(size_t downloadTotal, size_t downloadNow, size_t uploadTotal, size_t uploadNow, intptr_t userdata)> callback;
 };
 
 class DebugCallback {
@@ -59,9 +75,13 @@ class DebugCallback {
     };
     DebugCallback() = default;
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    DebugCallback(std::function<void(InfoType type, std::string data)> p_callback) : callback(std::move(p_callback)) {}
+    DebugCallback(std::function<void(InfoType type, std::string data, intptr_t userdata)> p_callback, intptr_t p_userdata = 0) : userdata(p_userdata), callback(std::move(p_callback)) {}
+    void operator()(InfoType type, std::string data) const {
+        callback(type, std::move(data), userdata);
+    }
 
-    std::function<void(InfoType type, std::string data)> callback;
+    intptr_t userdata;
+    std::function<void(InfoType type, std::string data, intptr_t userdata)> callback;
 };
 
 } // namespace cpr

--- a/test/callback_tests.cpp
+++ b/test/callback_tests.cpp
@@ -863,7 +863,7 @@ TEST(CallbackDataTests, CallbackWriteFunctionTextTest) {
 
 TEST(CallbackDataTests, CallbackProgressFunctionCancelTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
-    Response response = Post(url, ProgressCallback{[](intptr_t /*userdata*/, size_t /*downloadTotal*/, size_t /*downloadNow*/, size_t /*uploadTotal*/, size_t /*uploadNow*/) -> bool { return false; }});
+    Response response = Post(url, ProgressCallback{[](size_t /*downloadTotal*/, size_t /*downloadNow*/, size_t /*uploadTotal*/, size_t /*uploadNow*/, intptr_t /*userdata*/) -> bool { return false; }});
     EXPECT_EQ(response.error.code, ErrorCode::REQUEST_CANCELLED);
 }
 
@@ -871,7 +871,7 @@ TEST(CallbackDataTests, CallbackProgressFunctionTotalTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
     Body body{"x=5"};
     size_t response_upload = 0, response_download = 0;
-    Response response = Post(url, body, ProgressCallback{[&](intptr_t /*userdata*/, size_t downloadTotal, size_t /*downloadNow*/, size_t uploadTotal, size_t /*uploadNow*/) -> bool {
+    Response response = Post(url, body, ProgressCallback{[&](size_t downloadTotal, size_t /*downloadNow*/, size_t uploadTotal, size_t /*uploadNow*/, intptr_t /*userdata*/) -> bool {
                                  response_upload = uploadTotal;
                                  response_download = downloadTotal;
                                  return true;

--- a/test/callback_tests.cpp
+++ b/test/callback_tests.cpp
@@ -735,7 +735,7 @@ TEST(CallbackPatchTests, CallbackPatchFunctionTextReferenceTest) {
 
 TEST(CallbackDataTests, CallbackReadFunctionCancelTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
-    Response response = cpr::Post(url, cpr::ReadCallback([](char* /*buffer*/, size_t& /*size*/) -> size_t { return false; }));
+    Response response = cpr::Post(url, cpr::ReadCallback([](char* /*buffer*/, size_t& /*size*/, intptr_t /*userdata*/) -> size_t { return false; }));
     EXPECT_EQ(response.error.code, ErrorCode::REQUEST_CANCELLED);
 }
 
@@ -746,7 +746,7 @@ TEST(CallbackDataTests, CallbackReadFunctionTextTest) {
             "  \"x\": 5\n"
             "}"};
     unsigned count = 0;
-    Response response = cpr::Post(url, cpr::ReadCallback{3, [&](char* buffer, size_t& size) -> size_t {
+    Response response = cpr::Post(url, cpr::ReadCallback{3, [&](char* buffer, size_t& size, intptr_t /*userdata*/) -> size_t {
                                                              std::string data;
                                                              ++count;
                                                              switch (count) {
@@ -776,7 +776,7 @@ TEST(CallbackDataTests, CallbackReadFunctionHeaderTest) {
     std::string data = "Test";
     Response response = cpr::Post(url,
                                   cpr::ReadCallback{-1,
-                                                    [&](char* /*buffer*/, size_t& size) -> size_t {
+                                                    [&](char* /*buffer*/, size_t& size, intptr_t /*userdata*/) -> size_t {
                                                         size = 0;
                                                         return true;
                                                     }},
@@ -824,7 +824,7 @@ TEST(CallbackDataTests, CallbackReadFunctionChunkedTest) {
 
 TEST(CallbackDataTests, CallbackHeaderFunctionCancelTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
-    Response response = Post(url, HeaderCallback{[](std::string /*header*/) -> bool { return false; }});
+    Response response = Post(url, HeaderCallback{[](std::string /*header*/, intptr_t /*userdata*/) -> bool { return false; }});
     EXPECT_EQ(response.error.code, ErrorCode::REQUEST_CANCELLED);
 }
 
@@ -832,7 +832,7 @@ TEST(CallbackDataTests, CallbackHeaderFunctionTextTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
     std::vector<std::string> expected_headers{"HTTP/1.1 201 OK\r\n", "Content-Type: application/json\r\n", "\r\n"};
     std::set<std::string> response_headers;
-    Post(url, HeaderCallback{[&response_headers](std::string header) -> bool {
+    Post(url, HeaderCallback{[&response_headers](std::string header, intptr_t /*userdata*/) -> bool {
              response_headers.insert(header);
              return true;
          }});
@@ -843,7 +843,7 @@ TEST(CallbackDataTests, CallbackHeaderFunctionTextTest) {
 
 TEST(CallbackDataTests, CallbackWriteFunctionCancelTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
-    Response response = Post(url, WriteCallback{[](std::string /*header*/) -> bool { return false; }});
+    Response response = Post(url, WriteCallback{[](std::string /*header*/, intptr_t /*userdata*/) -> bool { return false; }});
     EXPECT_EQ(response.error.code, ErrorCode::REQUEST_CANCELLED);
 }
 
@@ -854,7 +854,7 @@ TEST(CallbackDataTests, CallbackWriteFunctionTextTest) {
             "  \"x\": 5\n"
             "}"};
     std::string response_text;
-    Post(url, Payload{{"x", "5"}}, WriteCallback{[&response_text](std::string header) -> bool {
+    Post(url, Payload{{"x", "5"}}, WriteCallback{[&response_text](std::string header, intptr_t /*userdata*/) -> bool {
              response_text.append(header);
              return true;
          }});
@@ -863,7 +863,7 @@ TEST(CallbackDataTests, CallbackWriteFunctionTextTest) {
 
 TEST(CallbackDataTests, CallbackProgressFunctionCancelTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
-    Response response = Post(url, ProgressCallback{[](size_t /*downloadTotal*/, size_t /*downloadNow*/, size_t /*uploadTotal*/, size_t /*uploadNow*/) -> bool { return false; }});
+    Response response = Post(url, ProgressCallback{[](intptr_t /*userdata*/, size_t /*downloadTotal*/, size_t /*downloadNow*/, size_t /*uploadTotal*/, size_t /*uploadNow*/) -> bool { return false; }});
     EXPECT_EQ(response.error.code, ErrorCode::REQUEST_CANCELLED);
 }
 
@@ -871,7 +871,7 @@ TEST(CallbackDataTests, CallbackProgressFunctionTotalTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
     Body body{"x=5"};
     size_t response_upload = 0, response_download = 0;
-    Response response = Post(url, body, ProgressCallback{[&](size_t downloadTotal, size_t /*downloadNow*/, size_t uploadTotal, size_t /*uploadNow*/) -> bool {
+    Response response = Post(url, body, ProgressCallback{[&](intptr_t /*userdata*/, size_t downloadTotal, size_t /*downloadNow*/, size_t uploadTotal, size_t /*uploadNow*/) -> bool {
                                  response_upload = uploadTotal;
                                  response_download = downloadTotal;
                                  return true;
@@ -884,7 +884,7 @@ TEST(CallbackDataTests, CallbackDebugFunctionTextTest) {
     Url url{server->GetBaseUrl() + "/url_post.html"};
     Body body{"x=5"};
     std::string debug_body;
-    Response response = Post(url, body, DebugCallback{[&](DebugCallback::InfoType type, std::string data) {
+    Response response = Post(url, body, DebugCallback{[&](DebugCallback::InfoType type, std::string data, intptr_t /*userdata*/) {
                                  if (type == DebugCallback::InfoType::DATA_OUT) {
                                      debug_body = data;
                                  }


### PR DESCRIPTION
Add UserData to the callback function to satisfy concurrent calls in a multi-threaded environment, and put the userdata parameter last.